### PR TITLE
Effects V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,10 @@ module Solutions.Example where
 
 import Dovin
 
-main = run formatter solution
-
 solution :: GameMonad ()
 solution = do
   step "Initial state" $ do
-    setLife Opponent 3
+    as Opponent $ setLife 3
 
     withLocation Hand $ addInstant "Plummet"
     withLocation Play $ do
@@ -46,9 +44,10 @@ solution = do
         withAttributes [flying, token] $ addCreature (4, 4) "Angel"
         withAttributes [flying]
           $ withEffect
-              matchInPlay
-              (matchOtherCreatures <> (const $ matchAttribute creature))
-              (pure . setAttribute hexproof)
+              (matchOtherCreatures <$> askSelf)
+              [ effectAddAbility hexproof
+              ]
+              "Other creatures gain hexproof"
           $ addCreature (3, 4) "Shalai, Voice of Plenty"
 
   step "Plummet to destroy Shalai" $ do

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ solutions for published Possibility Storm puzzles!)
   interactions.
 * `UltimateMasters` shows how to track opponent actions.
 * `ChannelFireball` automatically calculates High Tide mana.
-* `WarOfTheSpark2` shows off a hack for effects that depend on attributes of
-  other cards (hopefully will have a better fix in API soon!)
+* `WarOfTheSpark2` shows how to define effects that depend on attributes of
+  other cards.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ them as you would in a real game of paper magic.
 
 I've only added actions "as needed" to solve problems, so the built-in
 functions are rather incomplete right now. It is straightforward to add more
-though. See `src/Dovin/V2.hs` in conjuction with `src/Dovin/Actions.hs`.
+though. See `src/Dovin/V3.hs` in conjuction with `src/Dovin/Actions.hs`.
 
 ## Example
 

--- a/src/Dovin.hs
+++ b/src/Dovin.hs
@@ -1,5 +1,5 @@
 module Dovin
-  ( module Dovin.V2
+  ( module Dovin.V3
   ) where
 
-import Dovin.V2
+import Dovin.V3

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -1257,6 +1257,16 @@ setLife n = do
   actor <- view envActor
   assign (life . at actor) (Just n)
 
+-- | Adds an "until end of turn" effect to a card. Note in practice, since
+-- turns aren't modeled, the effect will stay around until the end of the
+-- solution.
+--
+-- > addEffect (effectPTSet 1 1) "Soldier"
+--
+-- [Effects]
+--
+--   * Adds a new "until end of turn" effect to the card with the current
+--   timestamp.
 addEffect :: LayeredEffectPart -> CardName -> GameMonad ()
 addEffect e cn = do
   card <- requireCard cn mempty

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -1260,6 +1260,6 @@ addEffect e cn = do
   card <- requireCard cn mempty
   now <- getTimestamp
 
-  let ae = AbilityEffect now EndOfTurn e
+  let ae = AbilityEffect now EndOfTurn [e]
 
   modifyCard cardAbilityEffects (\es -> ae:es) cn

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -1255,7 +1255,7 @@ setLife n = do
   actor <- view envActor
   assign (life . at actor) (Just n)
 
-addEffect :: LayeredEffect -> CardName -> GameMonad ()
+addEffect :: LayeredEffectPart -> CardName -> GameMonad ()
 addEffect e cn = do
   card <- requireCard cn mempty
   now <- getTimestamp

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -27,6 +27,7 @@ module Dovin.Actions (
   -- * Uncategorized
   , activate
   , activatePlaneswalker
+  , addEffect
   , attackWith
   , combatDamage
   , copySpell
@@ -1253,3 +1254,12 @@ setLife :: Int -> GameMonad ()
 setLife n = do
   actor <- view envActor
   assign (life . at actor) (Just n)
+
+addEffect :: LayeredEffect -> CardName -> GameMonad ()
+addEffect e cn = do
+  card <- requireCard cn mempty
+  now <- getTimestamp
+
+  let ae = AbilityEffect now EndOfTurn e
+
+  modifyCard cardAbilityEffects (\es -> ae:es) cn

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -77,6 +77,7 @@ import           Dovin.Prelude
 import           Dovin.Types
 import           Dovin.Builder
 import Dovin.Monad
+import Dovin.Matchers
 
 import qualified Data.HashMap.Strict as M
 import Data.Maybe (listToMaybe)

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -760,6 +760,8 @@ copySpell newName targetName = do
     stack
     ((:) newName)
 
+  resolveEffects
+
 -- | Applies damage from a source to a target.
 --
 -- > damage (const 2) (targetPlayer Opponent) "Shock"
@@ -797,9 +799,9 @@ damage f t source = action "damage" $ do
     throwError $ "damage must be positive, was " <> show dmg
 
   damage' dmg t c
-
   when (hasAttribute lifelink c) $
     modifying (life . at (fst . view location $ c) . non 0) (+ dmg)
+  resolveEffects
 
   where
     damage' dmg (TargetPlayer t) c =
@@ -954,6 +956,7 @@ remove :: CardName -> GameMonad ()
 remove cn = do
   modifying cards (M.delete cn)
   modifying stack (filter (/= cn))
+  resolveEffects
 
 -- | Remove mana from the pool. Colored mana will be removed first, then extra
 -- mana of any type will be removed to match the colorless required.
@@ -1227,6 +1230,7 @@ gainLife amount = do
   modifying
     (life . at actor . non 0)
     (+ amount)
+  resolveEffects
 
 -- | Decrements life total for current actor.
 --

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -1269,9 +1269,6 @@ setLife n = do
 --   timestamp.
 addEffect :: LayeredEffectPart -> CardName -> GameMonad ()
 addEffect e cn = do
-  card <- requireCard cn mempty
   now <- getTimestamp
 
-  let ae = AbilityEffect now EndOfTurn [e]
-
-  modifyCard cardAbilityEffects (\es -> ae:es) cn
+  modifyCard cardAbilityEffects (AbilityEffect now EndOfTurn [e]:) cn

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -76,8 +76,9 @@ import           Dovin.Helpers
 import           Dovin.Prelude
 import           Dovin.Types
 import           Dovin.Builder
-import Dovin.Monad
-import Dovin.Matchers
+import           Dovin.Monad
+import           Dovin.Matchers
+import           Dovin.Effects (resolveEffects)
 
 import qualified Data.HashMap.Strict as M
 import Data.Maybe (listToMaybe)

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -35,9 +35,9 @@ import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
 
 import Dovin.Attributes
---import Dovin.Actions
 import Dovin.Prelude
 import Dovin.Types
+import Dovin.Helpers (resolveEffects)
 
 addCard :: CardName -> GameMonad ()
 addCard name = do
@@ -47,6 +47,7 @@ addCard name = do
     Nothing -> do
       template <- view envTemplate
       modifying cards (M.insert name (BaseCard $ set cardName name template))
+      resolveEffects
 
 addAura :: CardName -> GameMonad ()
 addAura name = withAttribute aura $ addEnchantment name

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -40,7 +40,7 @@ import qualified Data.Set as S
 import Dovin.Attributes
 import Dovin.Prelude
 import Dovin.Types
-import Dovin.Helpers (resolveEffects, getTimestamp)
+import Dovin.Helpers (resolveEffects, getTimestamp, matchNone)
 
 addCard :: CardName -> GameMonad ()
 addCard name = do
@@ -126,7 +126,17 @@ withEffectV3 ::
  -> GameMonad ()
 withEffectV3 enabled appliesTo effect name =
   local (over (envTemplate . cardPassiveEffects)
-  (mkLayeredEffectPart enabled appliesTo effect name:))
+  (mkLayeredEffectPart combinedMatcher effect name:))
+
+  where
+    combinedMatcher :: EffectMonad CardMatcher
+    combinedMatcher = do
+      isEnabled <- enabled
+
+      if isEnabled then
+        appliesTo
+      else
+        return matchNone
 
 withCMC :: Int -> GameMonad () -> GameMonad ()
 withCMC n =

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -25,6 +25,7 @@ module Dovin.Builder (
   , withAttribute
   , withAttributes
   , withEffect
+  , withEffectV3
   , withLocation
   , withPlusOneCounters
   , withMinusOneCounters
@@ -110,6 +111,18 @@ withEffect ::
  -> GameMonad ()
 withEffect applyCondition filter action =
   local (over (envTemplate . cardEffects) (mkEffect applyCondition filter action:))
+
+-- | Add an effect to the created card.
+withEffectV3 ::
+    EffectMonad Bool
+ -> EffectMonad CardMatcher
+ -> (Card -> EffectMonad LayeredEffect)
+ -> EffectName
+ -> GameMonad ()
+ -> GameMonad ()
+withEffectV3 enabled appliesTo effect name =
+  local (over (envTemplate . cardPassiveEffects)
+  (mkLayeredEffect enabled appliesTo effect name:))
 
 withLocation :: Location -> GameMonad () -> GameMonad ()
 withLocation loc m = do

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -33,6 +33,7 @@ module Dovin.Builder (
   ) where
 
 import Control.Monad.Reader (ask, local)
+import Control.Monad.Identity (Identity)
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
 
@@ -109,7 +110,7 @@ withEffect ::
               -- apply. 'matchInPlay' is a typical value.
  -> (Card -> CardMatcher) -- ^ Given the current card, return a matcher that
                           -- matches cards that this affect applies to.
- -> (Card -> GameMonad Card) -- ^ Apply an effect to the given card.
+ -> (Card -> Identity Card) -- ^ Apply an effect to the given card.
  -> GameMonad ()
  -> GameMonad ()
 withEffect applyCondition filter action =

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -40,9 +40,9 @@ import qualified Data.Set as S
 import Dovin.Attributes
 import Dovin.Prelude
 import Dovin.Types
-import Dovin.Helpers (resolveEffects, getTimestamp)
+import Dovin.Helpers (getTimestamp)
 import Dovin.Matchers (matchNone)
-import Dovin.Effects (enabledInPlay)
+import Dovin.Effects (resolveEffects, enabledInPlay)
 
 addCard :: CardName -> GameMonad ()
 addCard name = do

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -119,13 +119,13 @@ withEffect applyCondition filter action =
 withEffectV3 ::
     EffectMonad Bool
  -> EffectMonad CardMatcher
- -> [LayeredEffect]
+ -> [LayeredEffectPart]
  -> EffectName
  -> GameMonad ()
  -> GameMonad ()
 withEffectV3 enabled appliesTo effect name =
   local (over (envTemplate . cardPassiveEffects)
-  (mkLayeredEffect enabled appliesTo effect name:))
+  (mkLayeredEffectPart enabled appliesTo effect name:))
 
 withCMC :: Int -> GameMonad () -> GameMonad ()
 withCMC n =

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -116,7 +116,7 @@ withEffect applyCondition filter action =
 withEffectV3 ::
     EffectMonad Bool
  -> EffectMonad CardMatcher
- -> (Card -> EffectMonad LayeredEffect)
+ -> [LayeredEffect]
  -> EffectName
  -> GameMonad ()
  -> GameMonad ()

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -157,8 +157,8 @@ withLocation loc m = do
 
   local (set (envTemplate . cardLocation) (p, loc)) m
 
--- | Set the owner for the created card. If not specified, it will default to
--- the owner of the card location.
+-- | Set the owner for the created card. If not specified, defaults to the
+-- owner of the card location.
 withOwner :: Player -> GameMonad () -> GameMonad ()
 withOwner owner = local (set envOwner (Just owner))
 

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -32,17 +32,16 @@ module Dovin.Builder (
   , withMinusOneCounters
   ) where
 
-import Control.Monad.Reader (ask, local)
-import Control.Monad.Identity (Identity)
-import qualified Data.HashMap.Strict as M
-import qualified Data.Set as S
-
 import Dovin.Attributes
 import Dovin.Prelude
 import Dovin.Types
 import Dovin.Helpers (getTimestamp)
 import Dovin.Matchers (matchNone)
 import Dovin.Effects (resolveEffects, enabledInPlay)
+
+import Control.Monad.Reader (local)
+import qualified Data.HashMap.Strict as M
+import qualified Data.Set as S
 
 addCard :: CardName -> GameMonad ()
 addCard name = do

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -40,7 +40,9 @@ import qualified Data.Set as S
 import Dovin.Attributes
 import Dovin.Prelude
 import Dovin.Types
-import Dovin.Helpers (resolveEffects, getTimestamp, matchNone, enabledInPlay)
+import Dovin.Helpers (resolveEffects, getTimestamp)
+import Dovin.Matchers (matchNone)
+import Dovin.Effects (enabledInPlay)
 
 addCard :: CardName -> GameMonad ()
 addCard name = do

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -27,6 +27,7 @@ module Dovin.Builder (
   , withCMC
   , withEffect
   , withEffectV3
+  , withEffectWhen
   , withLocation
   , withPlusOneCounters
   , withMinusOneCounters
@@ -40,7 +41,7 @@ import qualified Data.Set as S
 import Dovin.Attributes
 import Dovin.Prelude
 import Dovin.Types
-import Dovin.Helpers (resolveEffects, getTimestamp, matchNone)
+import Dovin.Helpers (resolveEffects, getTimestamp, matchNone, enabledInPlay)
 
 addCard :: CardName -> GameMonad ()
 addCard name = do
@@ -118,13 +119,21 @@ withEffect applyCondition filter action =
 
 -- | Add an effect to the created card.
 withEffectV3 ::
+    EffectMonad CardMatcher
+ -> [LayeredEffectPart]
+ -> EffectName
+ -> GameMonad ()
+ -> GameMonad ()
+withEffectV3 = withEffectWhen enabledInPlay
+
+withEffectWhen ::
     EffectMonad Bool
  -> EffectMonad CardMatcher
  -> [LayeredEffectPart]
  -> EffectName
  -> GameMonad ()
  -> GameMonad ()
-withEffectV3 enabled appliesTo effect name =
+withEffectWhen enabled appliesTo effect name =
   local (over (envTemplate . cardPassiveEffects)
   (mkLayeredEffectPart combinedMatcher effect name:))
 

--- a/src/Dovin/Effects.hs
+++ b/src/Dovin/Effects.hs
@@ -1,0 +1,203 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Dovin.Effects
+  ( effectPTSet
+  , effectPTSetF
+  , effectPTAdjustment
+  , effectPTAdjustmentF
+  , effectNoAbilities
+  , effectAddType
+
+  , resolveEffectsV3
+
+  , enabledInPlay
+
+  , viewSelf
+  , askSelf
+  )
+  where
+
+import Dovin.Prelude
+import Dovin.Types
+import Dovin.Matchers (applyMatcher, matchInPlay)
+
+import Control.Lens (makeLenses, over, view, set)
+import qualified Data.HashMap.Strict as M
+import qualified Data.Set as S
+import Control.Monad.Reader (ask, runReader)
+import Control.Monad.State (get)
+import Data.Maybe (mapMaybe)
+import Data.List (sortOn)
+
+type Pile = [PileEntry]
+data PileEntry = PileEntry
+  { _peSource :: Card
+  , _peTimestamp :: Timestamp
+  , _peEffect :: [LayeredEffectPart]
+  , _peAppliesTo :: [CardName]
+  }
+makeLenses ''PileEntry
+
+-- EFFECT BUILDERS
+--
+-- These create 'LayeredEffectPart', to be used in effect definitions.
+effectPTSet :: (Int, Int) -> LayeredEffectPart
+effectPTSet = effectPTSetF . const . pure
+
+effectPTSetF :: (Card -> EffectMonad (Int, Int)) -> LayeredEffectPart
+effectPTSetF f = LayeredEffectPart Layer7B $ \c -> do
+                   pt <- f c
+                   return $ set cardStrength (mkStrength pt) c
+
+effectPTAdjustment :: (Int, Int) -> LayeredEffectPart
+effectPTAdjustment = effectPTAdjustmentF . const . pure
+
+effectPTAdjustmentF :: (Card -> EffectMonad (Int, Int)) -> LayeredEffectPart
+effectPTAdjustmentF f = LayeredEffectPart Layer7C $ \c -> do
+                   pt <- f c
+                   return $ over cardStrength (mkStrength pt <>) c
+
+effectNoAbilities = LayeredEffectPart Layer6 (pure . set cardPassiveEffects mempty)
+
+effectAddType attr = LayeredEffectPart Layer4 (pure . over cardAttributes (S.insert attr))
+
+-- EFFECT DEFINITION HELPERS
+enabledInPlay :: EffectMonad Bool
+enabledInPlay = applyMatcher matchInPlay <$> askSelf
+
+askSelf :: EffectMonad Card
+askSelf = snd <$> ask
+
+viewSelf x = view x <$> askSelf
+
+-- Unlike the previous effects system, V3 attempts to better mirror the
+-- layering rules while also providing a more flexible API to create more types
+-- of effects. Some notable constraints this requires solving for include:
+--
+-- * The set of cards an effect applies to needs to be fixed in the first layer
+--   in which the effect would apply.
+-- * Layers can create or remove effects in higher layers (e.g. removing all
+--   abilities in layer 6). This means it is not possible to know all effects
+--   that will be applied at the start of the algorithm, effects need to be
+--   collected layer by layer.
+--
+-- This algorithm uses the concept of a "pile" of unapplied effects, that is
+-- both added to and reduced at each layer.
+--
+-- 1. For every layer, all cards are checked for effects that would start
+--    applying on that layer, and all parts of that effect are added to the
+--    pile - alongside the set of cards to apply to. For example, "all
+--    creatures are 0/1 and have no abilities" applies on both layers 6 and 7B
+--    and it will be added to the pile when evaluating layer 6.
+-- 2. All sub-effects that apply to the current layer are removed from the pile
+--    and evaluated in timestamp order. (Note: dependencies are not implemented
+--    yet.)
+-- 3. After the final layer, the pile should be empty.
+resolveEffectsV3 :: GameMonad ()
+resolveEffectsV3 = do
+  board <- get
+  cs <- resolveEffectsV3' board
+  assign resolvedCards cs
+
+  where
+    resolveEffectsV3' :: Board -> GameMonad (M.HashMap CardName Card)
+    resolveEffectsV3' board = do
+      let (newBoard, pile) = foldl resolveLayer (board, mempty) allLayers
+
+      unless (null pile) $ throwError "assertion failed: pile should be empty"
+
+      return $ view resolvedCards newBoard
+
+resolveLayer :: (Board, Pile) -> Layer -> (Board, Pile)
+resolveLayer (board, pile) layer =
+  let 
+    cs            = view resolvedCards board
+    newEffects    = concatMap (extractEffects layer) cs :: Pile
+    newPile       = pile <> newEffects :: Pile
+    (pile', peel) = peelLayer layer newPile
+    newBoard      = foldl applyEffects board . sortOn (view peTimestamp) $ peel
+  in
+  (newBoard, pile')
+
+  where
+    -- Take a PileEntry and apply it to the board state. It is assumed that it
+    -- has already been filtered to a single layer.
+    applyEffects :: Board -> PileEntry -> Board
+    applyEffects board pe =
+      let
+        cs = mapMaybe (\cn -> M.lookup cn (view resolvedCards board))
+             . view peAppliesTo
+             $ pe :: [Card]
+        newCards = map
+                     (applyEffectParts (view peSource pe) (view peEffect pe))
+                     cs
+      in
+
+      over
+        resolvedCards
+        (M.union . M.fromList . map (\c -> (view cardName c, c)) $ newCards)
+        board
+
+    applyEffectParts source es target =
+      foldl
+        (\t (LayeredEffectPart _ effect) ->
+          runReader (effect t) (board, source))
+        target
+        es
+
+    -- Find all effects on a card that begin applying at the given layer.
+    extractEffects :: Layer -> Card -> Pile
+    extractEffects layer c =
+      let
+        passiveEffects =
+          map toPileEntry
+          . view cardPassiveEffects
+          $ c
+        abilityEffects =
+          map (\(AbilityEffect t _ es) ->
+            PileEntry {
+              _peSource = c,
+              _peTimestamp = t,
+              _peEffect = es,
+              _peAppliesTo = [view cardName c]
+            })
+          . view cardAbilityEffects
+          $ c
+      in
+
+      filter
+        ((==) layer . minimum . map extractLayer . view peEffect)
+        (passiveEffects <> abilityEffects)
+
+      where
+        extractLayer (LayeredEffectPart l _) = l
+
+        toPileEntry :: LayeredEffectDefinition -> PileEntry
+        toPileEntry ld =
+          let
+            matcher = runReader (view leAppliesTo ld) (board, c)
+            cs' =
+              filter
+                (applyMatcher matcher)
+                (M.elems . view resolvedCards $ board)
+          in
+
+          PileEntry {
+            _peSource = c,
+            _peTimestamp = view cardTimestamp c,
+            _peEffect = view leEffect ld,
+            _peAppliesTo = map (view cardName) cs'
+          }
+
+-- Return two piles, the second including every effect part that applies at
+-- this layer, the first with all the remaining. Removes any entries that no
+-- longer have any effect parts remaining to apply.
+peelLayer :: Layer -> Pile -> (Pile, Pile)
+peelLayer layer pile =
+  (f not pile, f id pile)
+  where
+    f g =
+      filter (not . null . view peEffect)
+      . map (over peEffect (filter $ g . isLayer layer))
+
+    isLayer :: Layer -> LayeredEffectPart -> Bool
+    isLayer l1 (LayeredEffectPart l2 _) = l1 == l2

--- a/src/Dovin/Effects.hs
+++ b/src/Dovin/Effects.hs
@@ -2,8 +2,8 @@
 module Dovin.Effects
   ( effectPTSet
   , effectPTSetF
-  , effectPTAdjustment
-  , effectPTAdjustmentF
+  , effectPTAdjust
+  , effectPTAdjustF
   , effectNoAbilities
   , effectAddType
 
@@ -48,11 +48,11 @@ effectPTSetF f = LayeredEffectPart Layer7B $ \c -> do
                    pt <- f c
                    return $ set cardStrength (mkStrength pt) c
 
-effectPTAdjustment :: (Int, Int) -> LayeredEffectPart
-effectPTAdjustment = effectPTAdjustmentF . const . pure
+effectPTAdjust :: (Int, Int) -> LayeredEffectPart
+effectPTAdjust = effectPTAdjustF . const . pure
 
-effectPTAdjustmentF :: (Card -> EffectMonad (Int, Int)) -> LayeredEffectPart
-effectPTAdjustmentF f = LayeredEffectPart Layer7C $ \c -> do
+effectPTAdjustF :: (Card -> EffectMonad (Int, Int)) -> LayeredEffectPart
+effectPTAdjustF f = LayeredEffectPart Layer7C $ \c -> do
                    pt <- f c
                    return $ over cardStrength (mkStrength pt <>) c
 
@@ -156,7 +156,7 @@ resolveCounters board =
           if p == 0 && t == 0 then
             Nothing
           else
-            Just $ effectPTAdjustment (p, t)
+            Just $ effectPTAdjust (p, t)
 
         dup x = (x, x)
 

--- a/src/Dovin/Effects.hs
+++ b/src/Dovin/Effects.hs
@@ -19,6 +19,7 @@ module Dovin.Effects
   , enabledInPlay
 
   , viewSelf
+  , askCards
   , askSelf
   )
   where
@@ -86,6 +87,15 @@ askSelf = snd <$> ask
 
 -- | Apply a lens to 'askSelf'.
 viewSelf x = view x <$> askSelf
+
+-- | Return cards fitting the given matcher.
+askCards :: CardMatcher -> EffectMonad [Card]
+askCards matcher =
+  filter (applyMatcher matcher)
+  . M.elems
+  . view resolvedCards
+  . fst
+  <$> ask
 
 -- | Internal algorithm to apply re-calculate the state of the board by applying all effects.
 resolveEffects :: GameMonad ()

--- a/src/Dovin/Formatting.hs
+++ b/src/Dovin/Formatting.hs
@@ -1,17 +1,18 @@
 {-# LANGUAGE FlexibleContexts #-}
 module Dovin.Formatting where
 
+import Dovin.Helpers
+import Dovin.Matchers
+import Dovin.Monad
+import Dovin.Prelude
+import Dovin.Types
+
 import Control.Monad.Writer (Writer, execWriter, tell)
 
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
 import Data.List (intercalate, sort, sortBy, nub)
 import Data.Ord (comparing)
-
-import Dovin.Helpers
-import Dovin.Monad
-import Dovin.Prelude
-import Dovin.Types
 
 type FormatMonad = Writer [(String, GameMonad String)]
 

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -82,19 +82,7 @@ resolveEffects' board = foldM f mempty (M.toList $ view cards board)
 
       card' <- foldM (\c (e, _) -> applyEffect2 c e) card applicableEffects
 
-      -- TODO: Should be handled in Layer7C in V3 effects system
-      let plusModifier = let n = view cardPlusOneCounters card' in
-                              mkStrength (n, n)
-      let minusModifier = let n = view cardMinusOneCounters card' in
-                              mkStrength (-n, -n)
-
-      let strengthModifier = view cardStrengthModifier card'
-
-      return
-        $ over
-            cardStrength
-            ((strengthModifier <> plusModifier <> minusModifier) <>)
-            card'
+      return card'
 
       where
         applyEffect2 :: Card -> CardEffect -> GameMonad Card

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -302,6 +302,9 @@ matchController player = CardMatcher ("has controller " <> show player) $
 matchLesserPower n = CardMatcher ("power < " <> show n) $
   (< n) . view cardPower
 
+matchCard :: Card -> CardMatcher
+matchCard = matchName . view cardName
+
 matchToughness :: Int -> CardMatcher
 matchToughness n = labelMatch ("toughness = " <> show n) $ CardMatcher ""
   ((== n) . view cardToughness) <> matchAttribute creature

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -99,6 +99,3 @@ gameFinished = do
 
 getTimestamp :: GameMonad Timestamp
 getTimestamp = use currentTime
-
-askCards :: CardMatcher -> EffectMonad [Card]
-askCards matcher = filter (applyMatcher matcher) . map snd . M.toList . view resolvedCards . fst <$> ask

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -2,7 +2,6 @@
 
 module Dovin.Helpers where
 
-import Debug.Trace
 import Dovin.Types
 import Dovin.Attributes
 import Dovin.Prelude
@@ -11,8 +10,7 @@ import Data.List (sort, sortOn)
 import qualified Data.HashMap.Strict as M
 import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
-import Data.Char (isDigit)
-import Control.Lens (_1, _2, ASetter, both, _Just)
+import Control.Lens (_1, ASetter, _Just)
 import Control.Monad.State (get)
 import Control.Monad.Reader (ask, runReader)
 

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -2,17 +2,19 @@
 
 module Dovin.Helpers where
 
+import Debug.Trace
 import Dovin.Types
 import Dovin.Attributes
 import Dovin.Prelude
 
-import Data.List (sort)
+import Data.List (sort, sortOn)
 import qualified Data.HashMap.Strict as M
+import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
 import Data.Char (isDigit)
 import Control.Lens (_1, _2, ASetter, both, _Just)
 import Control.Monad.State (get)
-import Control.Monad.Reader (ask)
+import Control.Monad.Reader (ask, runReader)
 
 import Text.Parsec
 
@@ -52,11 +54,127 @@ requireCard name f = do
         Left msg ->
           throwError $ name <> " does not match requirements: " <> msg
 
+resolveEffectsV3 :: GameMonad ()
+resolveEffectsV3 = do
+  board <- get
+  cs <- resolveEffectsV3' board
+          --(set resolvedCards (M.map unwrap $ view cards board) board)
+  assign resolvedCards cs
+
+type Pile = [PileEntry]
+type PileEntry = (Card, Timestamp, [LayeredEffect], [Card])
+
+resolveLayer :: (Board, Pile) -> Layer -> (Board, Pile)
+resolveLayer (board, pile) layer =
+  let cs = view resolvedCards $ board in
+  let newEffects = concatMap (extractEffects layer) cs :: Pile in
+  let newPile = pile <> newEffects in
+  let (pile', peel) = peelLayer layer newPile in
+  let sortedPeel = sortOn (\(_, t, _, _) -> t) peel in
+  
+  let newBoard = foldl applyEffects board sortedPeel in
+
+  (newBoard, pile')
+
+  where
+    applyEffects :: Board -> PileEntry -> Board
+    applyEffects board (source, _, es, cs) =
+      let rcs = mapMaybe (\c -> M.lookup (view cardName c) (view resolvedCards board)) cs :: [Card] in
+      -- TODO: Assert (length rcs == length cs)
+      --
+      -- for each card, run ze monad
+      -- place new card into resolve cards in board
+      let newCards = map f rcs :: [Card] in
+
+      over resolvedCards (M.union $ M.fromList $ map (\c -> (view cardName c, c)) newCards) board
+
+      where
+        f :: Card -> Card
+        f target = foldl
+                (\t (LayeredEffect _ effect) ->
+                  runReader (effect t) (board, source))
+                target
+                es
+
+    extractEffects :: Layer -> Card -> Pile
+    extractEffects layer c =
+      let passiveEffects = map f . view cardPassiveEffects $ c in
+      let abilityEffects = map (\(AbilityEffect t _ es) -> (c, t, es, [c])) . view cardAbilityEffects $ c in
+
+      filter
+        (\(_, _, es, _) -> isLayer layer $ minimum es)
+        (passiveEffects <> abilityEffects)
+
+      where
+        f :: LayeredEffectDefinition -> PileEntry
+        f ld =
+          let matcher = runReader (view leAppliesTo ld) (board, c) in
+          let cs' = filter (applyMatcher matcher) (M.elems . view resolvedCards $ board) in
+
+          (c, view cardTimestamp c, view leEffect ld, cs')
+  
+peelLayer :: Layer -> Pile -> (Pile, Pile)
+peelLayer layer pile =
+  -- TODO: This is pretty inelegant
+  (
+    filter (\(_, _, es, _) -> (not . null) es) $ map (\(s, t, es, cs) -> (s, t, filter (not . isLayer layer) es, cs)) pile,
+    filter (\(_, _, es, _) -> (not . null) es) $ map (\(s, t, es, cs) -> (s, t, filter (isLayer layer) es, cs)) pile
+  )
+
+unwrap :: BaseCard -> Card
+unwrap (BaseCard card) = card
+
+isLayer :: Layer -> LayeredEffect -> Bool
+isLayer l1 (LayeredEffect l2 _) = l1 == l2
+
+resolveEffectsV3' :: Board -> GameMonad (M.HashMap CardName Card)
+resolveEffectsV3' board = do
+  let (newBoard, _) = foldl resolveLayer (board, mempty) allLayers
+      
+  return $ view resolvedCards newBoard
+  -- CONSTRAINTS
+  -- * the cards a composite effect applies to needs to be resolved in the
+  --   first layer the effect applies
+  -- * an effect that is collected early may not exist by the time it comes to
+  --   apply (e.g. layer 6 "remove all abilities" will remove any P/T in layer
+  --   7) EXCEPT if the composite effect started applying earlier (613.5)
+  --
+  -- 1) For each layer, get all effects that **start** on this layer
+  --      resolve their appliesTo (AbilityEffects apply to the current card)
+  --      include any effects that started on a previous layer but have a
+  --      subeffect on this layer
+  --      apply them all
+  --
+  --     type Pile = [(Timestamp, [LayeredEffect], [Card])]
+  --
+  --      Add cards with effects starting at this layer to "the pile", including with their "applies To" resolved
+  --
+  --      Reduce the pile by applying and removing all effects on this layer
+  --
+  --        peel :: Layer -> Pile -> (Pile, Pile)
+  --
+  --      Go to next layer
+  --
+  --      post condition - Pile has no layered effects remaining
+  --
+  -- 1) Collect all effects to be applied (filter out by leEnabled)
+  --      (Card, [(Timestamp, LayeredEffect)])
+  -- 2) Group by layer (can contain dups?)
+  --      HashMap Layer [(Card, [LayeredEffect], Maybe [Card])]
+  -- 3) For each layer
+  --    3a) sort cards by timestamp [ignore dependencies for now]
+  --    3b) for each card in layer
+  --      3b.i) if cards not resolved, resolved (leAppliesTo)
+  --      3b.ii) apply layer effects to each card in applies to
+
+
 resolveEffects :: GameMonad ()
 resolveEffects = do
   board <- get
   cs <- resolveEffects' board
   assign resolvedCards cs
+  modifying currentTime (+ 1)
+  resolveEffectsV3
 
 resolveEffects' :: Board -> GameMonad (M.HashMap CardName Card)
 resolveEffects' board = foldM f mempty (M.toList $ view cards board)
@@ -238,7 +356,7 @@ gameFinished = do
              _     -> False
 
 getTimestamp :: GameMonad Timestamp
-getTimestamp = return 0 -- TODO
+getTimestamp = use currentTime
 
 askCards :: CardMatcher -> EffectMonad [Card]
 askCards matcher = filter (applyMatcher matcher) . map snd . M.toList . view resolvedCards . fst <$> ask

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -154,13 +154,13 @@ resolveLayer (board, pile) layer =
             _peAppliesTo = cs'
           }
 
+-- Return two piles, the second including every effect part that applies at
+-- this layer, the first with all the remaining.
 peelLayer :: Layer -> Pile -> (Pile, Pile)
 peelLayer layer pile =
-  -- TODO: This is pretty inelegant
-  (
-    filter (not . null . view peEffect) $ map (over peEffect (filter $ not . isLayer layer)) pile,
-    filter (not . null . view peEffect) $ map (over peEffect (filter $ isLayer layer)) pile
-  )
+  (f not pile, f id pile)
+  where
+    f g = filter (not . null . view peEffect) . map (over peEffect (filter $ g . isLayer layer))
 
 unwrap :: BaseCard -> Card
 unwrap (BaseCard card) = card

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -3,17 +3,15 @@
 module Dovin.Helpers where
 
 import Dovin.Types
-import Dovin.Attributes
 import Dovin.Prelude
 import Dovin.Matchers
 import Dovin.Effects (resolveEffects)
 
-import Data.List (sort, sortOn)
+import Data.List (sort)
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
-import Control.Lens (_1, ASetter, _Just)
-import Control.Monad.State (get)
-import Control.Monad.Reader (ask, runReader)
+import Control.Lens (ASetter, _Just)
+import Control.Monad.Reader (ask)
 
 import Text.Parsec
 

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -5,23 +5,17 @@ module Dovin.Helpers where
 import Dovin.Types
 import Dovin.Attributes
 import Dovin.Prelude
+import Dovin.Effects (resolveEffectsV3)
+import Dovin.Matchers
 
 import Data.List (sort, sortOn)
 import qualified Data.HashMap.Strict as M
-import Data.Maybe (mapMaybe)
 import qualified Data.Set as S
 import Control.Lens (_1, ASetter, _Just)
 import Control.Monad.State (get)
 import Control.Monad.Reader (ask, runReader)
 
 import Text.Parsec
-
-applyMatcherWithDesc :: CardMatcher -> Card -> Either String ()
-applyMatcherWithDesc (CardMatcher d f) c =
-  if f c then
-    Right ()
-  else
-    Left d
 
 hasAttribute attr = S.member attr . view cardAttributes
 
@@ -51,139 +45,6 @@ requireCard name f = do
         Right () -> return card
         Left msg ->
           throwError $ name <> " does not match requirements: " <> msg
-
--- Unlike the previous effects system, V3 attempts to better mirror the
--- layering rules while also providing a more flexible API to create more types
--- of effects. Some notable constraints this requires solving for include:
---
--- * The set of cards an effect applies to needs to be fixed in the first layer
---   in which the effect would apply.
--- * Layers can create or remove effects in higher layers (e.g. removing all
---   abilities in layer 6). This means it is not possible to know all effects
---   that will be applied at the start of the algorithm, effects need to be
---   collected layer by layer.
---
--- This algorithm uses the concept of a "pile" of unapplied effects, that is
--- both added to and reduced at each layer.
---
--- 1. For every layer, all cards are checked for effects that would start
---    applying on that layer, and all parts of that effect are added to the
---    pile - alongside the set of cards to apply to. For example, "all
---    creatures are 0/1 and have no abilities" applies on both layers 6 and 7B
---    and it will be added to the pile when evaluating layer 6.
--- 2. All sub-effects that apply to the current layer are removed from the pile
---    and evaluated in timestamp order. (Note: dependencies are not implemented
---    yet.)
--- 3. After the final layer, the pile should be empty.
-resolveEffectsV3 :: GameMonad ()
-resolveEffectsV3 = do
-  board <- get
-  cs <- resolveEffectsV3' board
-  assign resolvedCards cs
-
-  where
-    resolveEffectsV3' :: Board -> GameMonad (M.HashMap CardName Card)
-    resolveEffectsV3' board = do
-      let (newBoard, pile) = foldl resolveLayer (board, mempty) allLayers
-
-      unless (null pile) $ throwError "assertion failed: pile should be empty"
-
-      return $ view resolvedCards newBoard
-
-resolveLayer :: (Board, Pile) -> Layer -> (Board, Pile)
-resolveLayer (board, pile) layer =
-  let 
-    cs            = view resolvedCards board
-    newEffects    = concatMap (extractEffects layer) cs :: Pile
-    newPile       = pile <> newEffects :: Pile
-    (pile', peel) = peelLayer layer newPile
-    newBoard      = foldl applyEffects board . sortOn (view peTimestamp) $ peel
-  in
-  (newBoard, pile')
-
-  where
-    -- Take a PileEntry and apply it to the board state. It is assumed that it
-    -- has already been filtered to a single layer.
-    applyEffects :: Board -> PileEntry -> Board
-    applyEffects board pe =
-      let
-        cs = mapMaybe (\cn -> M.lookup cn (view resolvedCards board))
-             . view peAppliesTo
-             $ pe :: [Card]
-        newCards = map
-                     (applyEffectParts (view peSource pe) (view peEffect pe))
-                     cs
-      in
-
-      over
-        resolvedCards
-        (M.union . M.fromList . map (\c -> (view cardName c, c)) $ newCards)
-        board
-
-    applyEffectParts source es target =
-      foldl
-        (\t (LayeredEffectPart _ effect) ->
-          runReader (effect t) (board, source))
-        target
-        es
-
-    -- Find all effects on a card that begin applying at the given layer.
-    extractEffects :: Layer -> Card -> Pile
-    extractEffects layer c =
-      let
-        passiveEffects =
-          map toPileEntry
-          . view cardPassiveEffects
-          $ c
-        abilityEffects =
-          map (\(AbilityEffect t _ es) ->
-            PileEntry {
-              _peSource = c,
-              _peTimestamp = t,
-              _peEffect = es,
-              _peAppliesTo = [view cardName c]
-            })
-          . view cardAbilityEffects
-          $ c
-      in
-
-      filter
-        ((==) layer . minimum . map extractLayer . view peEffect)
-        (passiveEffects <> abilityEffects)
-
-      where
-        extractLayer (LayeredEffectPart l _) = l
-
-        toPileEntry :: LayeredEffectDefinition -> PileEntry
-        toPileEntry ld =
-          let
-            matcher = runReader (view leAppliesTo ld) (board, c)
-            cs' =
-              filter
-                (applyMatcher matcher)
-                (M.elems . view resolvedCards $ board)
-          in
-
-          PileEntry {
-            _peSource = c,
-            _peTimestamp = view cardTimestamp c,
-            _peEffect = view leEffect ld,
-            _peAppliesTo = map (view cardName) cs'
-          }
-
--- Return two piles, the second including every effect part that applies at
--- this layer, the first with all the remaining. Removes any entries that no
--- longer have any effect parts remaining to apply.
-peelLayer :: Layer -> Pile -> (Pile, Pile)
-peelLayer layer pile =
-  (f not pile, f id pile)
-  where
-    f g =
-      filter (not . null . view peEffect)
-      . map (over peEffect (filter $ g . isLayer layer))
-
-    isLayer :: Layer -> LayeredEffectPart -> Bool
-    isLayer l1 (LayeredEffectPart l2 _) = l1 == l2
 
 resolveEffects :: GameMonad ()
 resolveEffects = do
@@ -262,89 +123,6 @@ modifyCardDeprecated name lens f = do
 
 modifyCard :: ASetter Card Card a b -> (a -> b) -> CardName -> GameMonad ()
 modifyCard lens f name = modifyCardDeprecated name lens f
-
--- CARD MATCHERS
---
--- Matchers are used for both filtering sets of cards, and also for verifying
--- attributes of cards.
-matchDamage :: Int -> CardMatcher
-matchDamage n = CardMatcher (show n <> " damage") $
-  (==) n . view cardDamage
-
-matchLoyalty :: Int -> CardMatcher
-matchLoyalty n = CardMatcher (show n <> " loyalty") $
-  (==) n . view cardLoyalty
-
-matchPlusOneCounters :: Int -> CardMatcher
-matchPlusOneCounters n = CardMatcher (show n <> " +1/+1 counters") $
-  (==) n . view cardPlusOneCounters
-
-matchMinusOneCounters :: Int -> CardMatcher
-matchMinusOneCounters n = CardMatcher (show n <> " -1/-1 counters") $
-  (==) n . view cardMinusOneCounters
-
-matchLocation :: CardLocation -> CardMatcher
-matchLocation loc = CardMatcher ("in location " <> show loc) $
-  (==) loc . view cardLocation
-
-matchInPlay = CardMatcher "in play" $ \c -> snd (view location c) == Play
-
-matchAttribute :: CardAttribute -> CardMatcher
-matchAttribute attr = CardMatcher ("has attribute " <> attr) $
-  S.member attr . view cardAttributes
-
-matchAttributes :: [CardAttribute] -> CardMatcher
-matchAttributes = foldr ((<>) . matchAttribute) mempty
-
-matchName :: CardName -> CardMatcher
-matchName n = CardMatcher ("has name " <> n) $ (==) n . view cardName
-
-matchOtherCreatures :: Card -> CardMatcher
-matchOtherCreatures = matchOther creature
-
-matchOther :: CardAttribute -> Card -> CardMatcher
-matchOther attribute card =
-     matchLocation (view cardLocation card)
-  <> matchAttribute attribute
-  <> invert (matchName (view cardName card))
-
-matchController player = CardMatcher ("has controller " <> show player) $
-  (==) player . view (location . _1)
-
-matchLesserPower n = CardMatcher ("power < " <> show n) $
-  (< n) . view cardPower
-
-matchNone = CardMatcher "never match" (const False)
-
-matchCard :: Card -> CardMatcher
-matchCard = matchName . view cardName
-
-matchToughness :: Int -> CardMatcher
-matchToughness n = labelMatch ("toughness = " <> show n) $ CardMatcher ""
-  ((== n) . view cardToughness) <> matchAttribute creature
-
-matchTarget :: Target -> CardMatcher
-matchTarget t = labelMatch ("target = " <> show t) $ CardMatcher ""
-  ((==) t . TargetCard . view cardName)
-
-enabledInPlay :: EffectMonad Bool
-enabledInPlay = applyMatcher matchInPlay <$> askSelf
-
-missingAttribute = invert . matchAttribute
-
-(CardMatcher d1 f) `matchOr` (CardMatcher d2 g) =
-    CardMatcher (d1 <> " or " <> d2) $ \c -> f c || g c
-
-invert :: CardMatcher -> CardMatcher
-invert (CardMatcher d f) = CardMatcher ("not " <> d) $ not . f
-
-labelMatch :: String -> CardMatcher -> CardMatcher
-labelMatch label (CardMatcher d f) = CardMatcher label f
-applyMatcher :: CardMatcher -> Card -> Bool
-applyMatcher matcher c =
-  case applyMatcherWithDesc matcher c of
-    Left _ -> False
-    Right _ -> True
 
 loseAttribute attr cn = do
   c <- requireCard cn mempty

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -133,7 +133,6 @@ resolveLayer (board, pile) layer =
       let
         passiveEffects =
           map toPileEntry
-          . filter isEnabled
           . view cardPassiveEffects
           $ c
         abilityEffects =
@@ -154,9 +153,6 @@ resolveLayer (board, pile) layer =
 
       where
         extractLayer (LayeredEffectPart l _) = l
-
-        isEnabled :: LayeredEffectDefinition -> Bool
-        isEnabled ld = runReader (view leEnabled ld) (board, c)
 
         toPileEntry :: LayeredEffectDefinition -> PileEntry
         toPileEntry ld =
@@ -317,6 +313,8 @@ matchController player = CardMatcher ("has controller " <> show player) $
 
 matchLesserPower n = CardMatcher ("power < " <> show n) $
   (< n) . view cardPower
+
+matchNone = CardMatcher "never match" (const False)
 
 matchCard :: Card -> CardMatcher
 matchCard = matchName . view cardName

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -98,7 +98,7 @@ resolveLayer (board, pile) layer =
 
     extractEffects :: Layer -> Card -> Pile
     extractEffects layer c =
-      let passiveEffects = map f . view cardPassiveEffects $ c in
+      let passiveEffects = map f . filter isEnabled . view cardPassiveEffects $ c in
       let abilityEffects = map (\(AbilityEffect t _ es) -> (c, t, es, [c])) . view cardAbilityEffects $ c in
 
       filter
@@ -106,6 +106,9 @@ resolveLayer (board, pile) layer =
         (passiveEffects <> abilityEffects)
 
       where
+        isEnabled :: LayeredEffectDefinition -> Bool
+        isEnabled ld = runReader (view leEnabled ld) (board, c)
+
         f :: LayeredEffectDefinition -> PileEntry
         f ld =
           let matcher = runReader (view leAppliesTo ld) (board, c) in

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -313,6 +313,9 @@ matchTarget :: Target -> CardMatcher
 matchTarget t = labelMatch ("target = " <> show t) $ CardMatcher ""
   ((==) t . TargetCard . view cardName)
 
+enabledInPlay :: EffectMonad Bool
+enabledInPlay = applyMatcher matchInPlay <$> askSelf
+
 missingAttribute = invert . matchAttribute
 
 (CardMatcher d1 f) `matchOr` (CardMatcher d2 g) =

--- a/src/Dovin/Matchers.hs
+++ b/src/Dovin/Matchers.hs
@@ -67,6 +67,14 @@ matchToughness :: Int -> CardMatcher
 matchToughness n = labelMatch ("toughness = " <> show n) $ CardMatcher ""
   ((== n) . view cardToughness) <> matchAttribute creature
 
+matchPower :: Int -> CardMatcher
+matchPower n = labelMatch ("power = " <> show n) $ CardMatcher ""
+  ((== n) . view cardPower) <> matchAttribute creature
+
+matchStrength :: (Int, Int) -> CardMatcher
+matchStrength (p, t) = labelMatch ("P/T = " <> show p <> "/" <> show t) $
+  matchPower p <> matchToughness t
+
 matchTarget :: Target -> CardMatcher
 matchTarget t = labelMatch ("target = " <> show t) $ CardMatcher ""
   ((==) t . TargetCard . view cardName)

--- a/src/Dovin/Matchers.hs
+++ b/src/Dovin/Matchers.hs
@@ -1,0 +1,96 @@
+module Dovin.Matchers where
+
+import Dovin.Prelude
+import Dovin.Attributes (creature)
+import Dovin.Types
+
+import qualified Data.Set as S
+import Control.Lens (_1)
+
+-- CARD MATCHERS
+--
+-- Matchers are used for both filtering sets of cards, and also for verifying
+-- attributes of cards.
+matchDamage :: Int -> CardMatcher
+matchDamage n = CardMatcher (show n <> " damage") $
+  (==) n . view cardDamage
+
+matchLoyalty :: Int -> CardMatcher
+matchLoyalty n = CardMatcher (show n <> " loyalty") $
+  (==) n . view cardLoyalty
+
+matchPlusOneCounters :: Int -> CardMatcher
+matchPlusOneCounters n = CardMatcher (show n <> " +1/+1 counters") $
+  (==) n . view cardPlusOneCounters
+
+matchMinusOneCounters :: Int -> CardMatcher
+matchMinusOneCounters n = CardMatcher (show n <> " -1/-1 counters") $
+  (==) n . view cardMinusOneCounters
+
+matchLocation :: CardLocation -> CardMatcher
+matchLocation loc = CardMatcher ("in location " <> show loc) $
+  (==) loc . view cardLocation
+
+matchInPlay = CardMatcher "in play" $ \c -> snd (view location c) == Play
+
+matchAttribute :: CardAttribute -> CardMatcher
+matchAttribute attr = CardMatcher ("has attribute " <> attr) $
+  S.member attr . view cardAttributes
+
+matchAttributes :: [CardAttribute] -> CardMatcher
+matchAttributes = foldr ((<>) . matchAttribute) mempty
+
+matchName :: CardName -> CardMatcher
+matchName n = CardMatcher ("has name " <> n) $ (==) n . view cardName
+
+matchOtherCreatures :: Card -> CardMatcher
+matchOtherCreatures = matchOther creature
+
+matchOther :: CardAttribute -> Card -> CardMatcher
+matchOther attribute card =
+     matchLocation (view cardLocation card)
+  <> matchAttribute attribute
+  <> invert (matchName (view cardName card))
+
+matchController player = CardMatcher ("has controller " <> show player) $
+  (==) player . view (location . _1)
+
+matchLesserPower n = CardMatcher ("power < " <> show n) $
+  (< n) . view cardPower
+
+matchNone = CardMatcher "never match" (const False)
+
+matchCard :: Card -> CardMatcher
+matchCard = matchName . view cardName
+
+matchToughness :: Int -> CardMatcher
+matchToughness n = labelMatch ("toughness = " <> show n) $ CardMatcher ""
+  ((== n) . view cardToughness) <> matchAttribute creature
+
+matchTarget :: Target -> CardMatcher
+matchTarget t = labelMatch ("target = " <> show t) $ CardMatcher ""
+  ((==) t . TargetCard . view cardName)
+
+missingAttribute = invert . matchAttribute
+
+(CardMatcher d1 f) `matchOr` (CardMatcher d2 g) =
+    CardMatcher (d1 <> " or " <> d2) $ \c -> f c || g c
+
+invert :: CardMatcher -> CardMatcher
+invert (CardMatcher d f) = CardMatcher ("not " <> d) $ not . f
+
+labelMatch :: String -> CardMatcher -> CardMatcher
+labelMatch label (CardMatcher d f) = CardMatcher label f
+
+applyMatcherWithDesc :: CardMatcher -> Card -> Either String ()
+applyMatcherWithDesc (CardMatcher d f) c =
+  if f c then
+    Right ()
+  else
+    Left d
+
+applyMatcher :: CardMatcher -> Card -> Bool
+applyMatcher matcher c =
+  case applyMatcherWithDesc matcher c of
+    Left _ -> False
+    Right _ -> True

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -69,12 +69,10 @@ type LayeredEffect = [LayeredEffectPart]
 -- can generated different effects affecting different cards depending on the
 -- state of the board.
 data LayeredEffectDefinition = LayeredEffectDefinition
-  -- ^ Filter to determine which cards are affected by this effect, if enabled.
-  { _leAppliesTo :: EffectMonad CardMatcher
-  -- ^ The actions to apply to affected cards.
-  , _leEffect :: LayeredEffect
-  -- ^ A human readable description of the effect. Optional.
-  , _leName :: EffectName
+  {
+  _leAppliesTo :: EffectMonad CardMatcher -- ^ Filter to determine which cards are affected by this effect, if enabled.
+  , _leEffect :: LayeredEffect -- ^ The actions to apply to affected cards.
+  , _leName :: EffectName -- ^ A human readable description of the effect. Optional.
   }
 
 

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -3,7 +3,7 @@
 
 module Dovin.Types where
 
-import Control.Lens (Lens', Prism', makeLenses, over, view, _1, _2, _Just, at, non, set)
+import Control.Lens (Lens', makeLenses, over, view, _1, _2, at, non, set)
 import Control.Monad.Reader (ReaderT, Reader, ask)
 import Control.Monad.Except (ExceptT)
 import Control.Monad.Identity (Identity)
@@ -81,9 +81,7 @@ data LayeredEffectDefinition = LayeredEffectDefinition
 askSelf :: EffectMonad Card
 askSelf = snd <$> ask
 
-viewSelf x = do
-  self <- askSelf
-  return (view x self)
+viewSelf x = view x <$> askSelf
 
 mkEffect enabled filter action = CardEffect
   -- For an effect to be enabled, it's host card must currently match this

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -141,6 +141,7 @@ data AbilityEffect = AbilityEffect Timestamp EffectDuration [LayeredEffectPart]
 data Card = Card
   { _cardName :: CardName
   , _location :: (Player, Location)
+  , _cardOwner :: Player
   , _cardDefaultAttributes :: CardAttributes
   , _cardAttributes :: CardAttributes
   , _cardStrength :: CardStrength
@@ -201,6 +202,7 @@ data Env = Env
   { _envTemplate :: Card
   , _envSBAEnabled :: Bool
   , _envActor :: Player
+  , _envOwner :: Maybe Player
   }
 
 type StepIdentifier = (Maybe String, Int)
@@ -238,9 +240,6 @@ mkStep id label state = Step
 
 cardLocation :: Control.Lens.Lens' Card (Player, Location)
 cardLocation = location
-
-cardOwner :: Control.Lens.Lens' Card Player
-cardOwner = cardLocation . _1
 
 -- TODO: How to define these lenses using built-in Lens primitives
 -- (Control.Lens.Wrapped?)
@@ -289,6 +288,7 @@ emptyEnv = Env
   { _envTemplate = emptyCard
   , _envSBAEnabled = True
   , _envActor = Active
+  , _envOwner = Nothing
   }
 
 mkStrength (p, t) = CardStrength p t
@@ -297,6 +297,7 @@ mkCard name location =
   Card
     { _cardName = name
     , _location = location
+    , _cardOwner = fst location
     , _cardDefaultAttributes = mempty
     , _cardColors = mempty
     , _cardAttributes = mempty

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -364,6 +364,6 @@ data PileEntry = PileEntry
   { _peSource :: Card
   , _peTimestamp :: Timestamp
   , _peEffect :: [LayeredEffectPart]
-  , _peAppliesTo :: [Card]
+  , _peAppliesTo :: [CardName]
   }
 makeLenses ''PileEntry

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -5,6 +5,7 @@ module Dovin.Types where
 
 import Control.Lens (Lens', makeLenses, over, view, _1, _2, at, non, set)
 import Control.Monad.Reader (ReaderT, Reader, ask)
+import Control.Monad.Identity (runIdentity)
 import Control.Monad.Except (ExceptT)
 import Control.Monad.Identity (Identity)
 import Control.Monad.State (StateT)
@@ -83,6 +84,11 @@ askSelf = snd <$> ask
 
 viewSelf x = view x <$> askSelf
 
+mkEffect ::
+  CardMatcher
+  -> (Card -> CardMatcher)
+  -> (Card -> Identity Card)
+  -> CardEffect
 mkEffect enabled filter action = CardEffect
   -- For an effect to be enabled, it's host card must currently match this
   -- matcher.
@@ -91,7 +97,7 @@ mkEffect enabled filter action = CardEffect
   -- card is affected by it.
   , _effectFilter = filter
   -- The action to apply to affected cards.
-  , _effectAction = action
+  , _effectAction = return . runIdentity . action
   }
 
 mkLayeredEffectPart enabled appliesTo effect name = LayeredEffectDefinition

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -346,10 +346,12 @@ effectProtectionF :: (Card -> EffectMonad Colors) -> LayeredEffect
 effectProtectionF f = LayeredEffect Layer6 $ \c -> do
                         colors <- f c
                         return c -- TODO
---effectPTAdjustment p t = EffectPTAdjustment $ mkStrength (p, t)
---effectPTSet p t = EffectPTSet $ mkStrength (p, t)
---effectNoAbilities = EffectNoAbilities
---effectProtection = EffectProtection
---effectType = EffectType
 
-data CompositeEffect = CompositeEffect [LayeredEffect]
+type Pile = [PileEntry]
+data PileEntry = PileEntry
+  { _peSource :: Card
+  , _peTimestamp :: Timestamp
+  , _peEffect :: [LayeredEffect]
+  , _peAppliesTo :: [Card]
+  }
+makeLenses ''PileEntry

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -101,6 +101,8 @@ type EffectName = String
 
 data Board = Board
   { _cards :: M.HashMap CardName BaseCard
+  , _resolvedCards :: M.HashMap CardName Card
+
   -- The stack is currently the only location where we care about order, so
   -- store that information alongside the main _cards map. This won't scale -
   -- deck and graveyard need to be ordered also - but works for now. Need to
@@ -234,6 +236,7 @@ opposing Opponent = Active
 
 emptyBoard = Board
                { _cards = mempty
+               , _resolvedCards = mempty
                , _counters = mempty
                , _stack = mempty
                , _deck = mempty

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -66,13 +66,15 @@ data LayeredEffectPart = LayeredEffectPart Layer (Card -> EffectMonad Card)
 type LayeredEffect = [LayeredEffectPart]
 
 -- An effect definition best matches up to the text describing it on a card. It
--- can generated different effects affecting different cards depending on the
+-- can generate different effects affecting different cards depending on the
 -- state of the board.
 data LayeredEffectDefinition = LayeredEffectDefinition
-  {
-  _leAppliesTo :: EffectMonad CardMatcher -- ^ Filter to determine which cards are affected by this effect, if enabled.
+  { _leAppliesTo :: EffectMonad CardMatcher -- ^ Filter to determine which
+                                            -- cards are affected by this
+                                            -- effect, if enabled.
   , _leEffect :: LayeredEffect -- ^ The actions to apply to affected cards.
-  , _leName :: EffectName -- ^ A human readable description of the effect. Optional.
+  , _leName :: EffectName      -- ^ A human readable description of the effect.
+                               -- Optional.
   }
 
 
@@ -257,6 +259,8 @@ cardToughness f parent = fmap
     setToughness t (CardStrength p _) = CardStrength p t
     toughness (CardStrength _ t) = t
 
+cardController :: Control.Lens.Lens' Card Player
+cardController = cardLocation . _1
 
 manaPoolFor p = manaPool . at p . non mempty
 

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -3,11 +3,10 @@
 
 module Dovin.Types where
 
-import Control.Lens (Lens', makeLenses, over, view, _1, _2, at, non, set)
-import Control.Monad.Reader (ReaderT, Reader, ask)
-import Control.Monad.Identity (runIdentity)
+import Control.Lens (Lens', makeLenses, over, view, _1, _2, at, non)
+import Control.Monad.Reader (ReaderT, Reader)
+import Control.Monad.Identity (runIdentity, Identity)
 import Control.Monad.Except (ExceptT)
-import Control.Monad.Identity (Identity)
 import Control.Monad.State (StateT)
 import Control.Monad.Writer (WriterT)
 import qualified Data.HashMap.Strict as M

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -69,10 +69,8 @@ type LayeredEffect = [LayeredEffectPart]
 -- can generated different effects affecting different cards depending on the
 -- state of the board.
 data LayeredEffectDefinition = LayeredEffectDefinition
-  -- ^ Whether or not to apply this effect.
-  { _leEnabled :: EffectMonad Bool
   -- ^ Filter to determine which cards are affected by this effect, if enabled.
-  , _leAppliesTo :: EffectMonad CardMatcher
+  { _leAppliesTo :: EffectMonad CardMatcher
   -- ^ The actions to apply to affected cards.
   , _leEffect :: LayeredEffect
   -- ^ A human readable description of the effect. Optional.
@@ -100,9 +98,8 @@ mkEffect enabled filter action = CardEffect
   , _effectAction = return . runIdentity . action
   }
 
-mkLayeredEffectPart enabled appliesTo effect name = LayeredEffectDefinition
-  { _leEnabled = enabled
-  , _leAppliesTo = appliesTo
+mkLayeredEffectPart appliesTo effect name = LayeredEffectDefinition
+  { _leAppliesTo = appliesTo
   , _leEffect = effect
   , _leName = name
   }

--- a/src/Dovin/V1.hs
+++ b/src/Dovin/V1.hs
@@ -6,6 +6,7 @@ module Dovin.V1
   , module Dovin.Formatting
   , module Dovin.Helpers
   , module Dovin.Types
+  , module Dovin.Matchers
   , validate
   , validateLife
   , withLocation
@@ -24,6 +25,7 @@ import Dovin.Formatting
 import Dovin.Helpers
 import Dovin.Monad
 import Dovin.Types
+import Dovin.Matchers
 
 import Control.Monad (forM_)
 import Control.Monad.State (put, get)

--- a/src/Dovin/V2.hs
+++ b/src/Dovin/V2.hs
@@ -18,6 +18,7 @@ module Dovin.V2
   , module Dovin.Formatting
   , module Dovin.Helpers
   , module Dovin.Types
+  , module Dovin.Matchers
   , view
   , withEffect
   )
@@ -33,6 +34,7 @@ import Dovin.Builder hiding (withEffect)
 import Dovin.Formatting
 import Dovin.Helpers
 import Dovin.Monad
+import Dovin.Matchers
 import Dovin.Types hiding
   ( cards
   , stack

--- a/src/Dovin/V2.hs
+++ b/src/Dovin/V2.hs
@@ -26,14 +26,11 @@ module Dovin.V2
 
 import Dovin.Runner
 import Dovin.Actions
-import qualified Dovin.V1
 import Dovin.V1 (withEffect)
-import Dovin.Prelude
 import Dovin.Attributes
 import Dovin.Builder hiding (withEffect)
 import Dovin.Formatting
 import Dovin.Helpers
-import Dovin.Monad
 import Dovin.Matchers
 import Dovin.Types hiding
   ( cards

--- a/src/Dovin/V2.hs
+++ b/src/Dovin/V2.hs
@@ -31,5 +31,13 @@ import Dovin.Builder
 import Dovin.Formatting
 import Dovin.Helpers
 import Dovin.Monad
-import Dovin.Types
+import Dovin.Types hiding
+  ( cards
+  , stack
+  , deck
+  , life
+  , manaPool
+  , phase
+  , currentStep
+  )
 import Control.Lens (view)

--- a/src/Dovin/V2.hs
+++ b/src/Dovin/V2.hs
@@ -39,5 +39,6 @@ import Dovin.Types hiding
   , manaPool
   , phase
   , currentStep
+  , resolvedCards
   )
 import Control.Lens (view)

--- a/src/Dovin/V2.hs
+++ b/src/Dovin/V2.hs
@@ -19,15 +19,17 @@ module Dovin.V2
   , module Dovin.Helpers
   , module Dovin.Types
   , view
+  , withEffect
   )
   where
 
 import Dovin.Runner
 import Dovin.Actions
 import qualified Dovin.V1
+import Dovin.V1 (withEffect)
 import Dovin.Prelude
 import Dovin.Attributes
-import Dovin.Builder
+import Dovin.Builder hiding (withEffect)
 import Dovin.Formatting
 import Dovin.Helpers
 import Dovin.Monad

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -1,0 +1,19 @@
+{-|
+V3 introduces a new effects system that is incompatible with V2 effects. V3
+effects are more flexible and better align with the layer system. It also adds
+some new card properties.
+
+* `withEffect` has a new, more flexible API.
+* `withEffectWhen` added as a version of `withEffect` that allows customization
+   of then the effect should apply (by default they apply when card is in
+   play).
+* added `withCMC` to set converted mana cost on cards.
+-}
+module Dovin.V3
+  ( module Dovin.V2
+  , module Dovin.Builder
+  )
+  where
+
+import Dovin.V2 hiding (withEffect)
+import Dovin.Builder (withEffect)

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -34,5 +34,6 @@ import Dovin.Effects
   , enabledInPlay
   , viewSelf
   , askSelf
+  , askCards
   )
 

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -24,3 +24,15 @@ module Dovin.V3
 import Dovin.V2 hiding (withEffect, cardStrengthModifier)
 import Dovin.Builder (withEffect)
 import Dovin.Effects
+  ( effectPTSet
+  , effectPTSetF
+  , effectPTAdjust
+  , effectPTAdjustF
+  , effectAddAbility
+  , effectNoAbilities
+  , effectAddType
+  , enabledInPlay
+  , viewSelf
+  , askSelf
+  )
+

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -9,7 +9,7 @@ some new card properties.
    play).
 * `withCMC` to set converted mana cost on cards.
 * `addEffect` to apply an effect to a card. In combination with
-  `effectPTAdjustment` this replaces altering `cardStrengthModifier` directly,
+  `effectPTAdjust` this replaces altering `cardStrengthModifier` directly,
   which is now removed.
 * Added a suite of `effect*` builders for effects.
 -}

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -16,8 +16,10 @@ some new card properties.
 module Dovin.V3
   ( module Dovin.V2
   , module Dovin.Builder
+  , module Dovin.Effects
   )
   where
 
 import Dovin.V2 hiding (withEffect, cardStrengthModifier)
 import Dovin.Builder (withEffect)
+import Dovin.Effects

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -7,7 +7,11 @@ some new card properties.
 * `withEffectWhen` added as a version of `withEffect` that allows customization
    of then the effect should apply (by default they apply when card is in
    play).
-* added `withCMC` to set converted mana cost on cards.
+* `withCMC` to set converted mana cost on cards.
+* `addEffect` to apply an effect to a card. In combination with
+  `effectPTAdjustment` this replaces altering `cardStrengthModifier` directly,
+  which is now removed.
+* Added a suite of `effect*` builders for effects.
 -}
 module Dovin.V3
   ( module Dovin.V2
@@ -15,5 +19,5 @@ module Dovin.V3
   )
   where
 
-import Dovin.V2 hiding (withEffect)
+import Dovin.V2 hiding (withEffect, cardStrengthModifier)
 import Dovin.Builder (withEffect)

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -12,6 +12,7 @@ some new card properties.
   `effectPTAdjust` this replaces altering `cardStrengthModifier` directly,
   which is now removed.
 * Added a suite of `effect*` builders for effects.
+* Added `cardOwner` property to cards, and `withOwner` fluid builder to set it.
 -}
 module Dovin.V3
   ( module Dovin.V2

--- a/src/Solutions/ChannelFireball.hs
+++ b/src/Solutions/ChannelFireball.hs
@@ -3,9 +3,7 @@ module Solutions.ChannelFireball where
 import Dovin.V2
 import Dovin.Prelude
 
-import Data.List (delete)
 import Control.Lens
-import Debug.Trace
 
 solution :: GameMonad ()
 solution = do

--- a/src/Solutions/Example.hs
+++ b/src/Solutions/Example.hs
@@ -16,9 +16,10 @@ solution = do
         withAttributes [flying, token] $ addCreature (4, 4) "Angel"
         withAttributes [flying]
           $ withEffect
-              matchInPlay
-              (matchOtherCreatures <> (const $ matchAttribute creature))
-              (pure . setAttribute hexproof)
+              (matchOtherCreatures <$> askSelf)
+              [ effectAddAbility hexproof
+              ]
+              "Other creatures gain hexproof"
           $ addCreature (3, 4) "Shalai, Voice of Plenty"
 
   step "Plummet to destroy Shalai" $ do

--- a/src/Solutions/RavnicaAllegiance4.hs
+++ b/src/Solutions/RavnicaAllegiance4.hs
@@ -1,7 +1,6 @@
 module Solutions.RavnicaAllegiance4 where
 
 import Dovin.V2
-import Dovin.Prelude
 
 solution :: GameMonad ()
 solution = do

--- a/src/Solutions/RavnicaAllegiance5.hs
+++ b/src/Solutions/RavnicaAllegiance5.hs
@@ -1,7 +1,6 @@
 module Solutions.RavnicaAllegiance5 where
 
 import Dovin.V2
-import Dovin.Prelude
 
 tapWithFreyalise mana card = do
   validate matchInPlay "Song of Freyalise"

--- a/src/Solutions/RavnicaAllegiancePre2.hs
+++ b/src/Solutions/RavnicaAllegiancePre2.hs
@@ -1,11 +1,6 @@
 module Solutions.RavnicaAllegiancePre2 where
 
 import Dovin.V2
-import Dovin.Prelude
-
-import Data.List (delete)
-import Control.Lens
-import Debug.Trace
 
 solution :: GameMonad ()
 solution = do

--- a/src/Solutions/RivalsOfIxalan7.hs
+++ b/src/Solutions/RivalsOfIxalan7.hs
@@ -23,7 +23,7 @@ solution = do
             (    matchLocation . view cardLocation
               <> const (matchAttribute creature)
             )
-            (pure . over cardStrengthModifier (mkStrength (1, 1) <>))
+            (pure . over cardStrength (mkStrength (1, 1) <>))
         $ addCreature (2, 2) "Tah-Crop Elite"
 
     withLocation (Active, Hand) $ do

--- a/src/Solutions/WarOfTheSpark2.hs
+++ b/src/Solutions/WarOfTheSpark2.hs
@@ -37,7 +37,7 @@ solution = do
             return $ length dinos > 0
           )
           (matchCard <$> askSelf)
-          [ effectPTAdjustment (2, 2)
+          [ effectPTAdjust (2, 2)
           ]
           "+2/+2 so long as you control another dinosaur"
             $ addCreature (1, 1) "Drover of the Mighty"
@@ -86,7 +86,7 @@ solution = do
 
     withStateBasedActions $ do
       forCards (matchInPlay <> matchAttribute creature <> invert (matchName "Massacre Girl")) $ \cn -> do
-        addEffect (effectPTAdjustment (-1, -1)) cn
+        addEffect (effectPTAdjust (-1, -1)) cn
 
     validate (matchLocation (Opponent, Graveyard)) "Drover of the Mighty"
 
@@ -104,7 +104,7 @@ solution = do
 
     withStateBasedActions $ do
       forCards (matchInPlay <> matchAttribute creature <> invert (matchName "Massacre Girl")) $ \cn -> do
-        addEffect (effectPTAdjustment (-1, -1)) cn
+        addEffect (effectPTAdjust (-1, -1)) cn
 
     -- Active player triggers stack first
     validate (matchLocation (Active, Graveyard)) "Merfolk Trickster"
@@ -127,14 +127,14 @@ solution = do
 
     withStateBasedActions $ do
       forCards (matchInPlay <> matchAttribute creature <> invert (matchName "Massacre Girl")) $ \cn -> do
-        addEffect (effectPTAdjustment (-1, -1)) cn
+        addEffect (effectPTAdjust (-1, -1)) cn
 
   step "Resolve -1/-1 for Trickster" $ do
     resolve "-1/-1 Trickster"
 
     withStateBasedActions $ do
       forCards (matchInPlay <> matchAttribute creature <> invert (matchName "Massacre Girl")) $ \cn -> do
-        addEffect (effectPTAdjustment (-1, -1)) cn
+        addEffect (effectPTAdjust (-1, -1)) cn
 
   step "Return Trickster to play from Ghostform, targeting God-Eternal" $ do
     moveTo Play "Merfolk Trickster"

--- a/src/Solutions/WarOfTheSpark2.hs
+++ b/src/Solutions/WarOfTheSpark2.hs
@@ -1,7 +1,6 @@
 module Solutions.WarOfTheSpark2 where
 
 import Dovin.V3
-import Dovin.Prelude
 
 dinosaur = "dinosaur"
 

--- a/src/Solutions/WarOfTheSpark2.hs
+++ b/src/Solutions/WarOfTheSpark2.hs
@@ -28,7 +28,7 @@ solution = do
         addCreature (3, 2) "Midnight Reaper"
         withEffectWhen
           (do
-            controller <- viewSelf cardOwner
+            controller <- viewSelf cardController
             dinos <- askCards $ matchAttribute dinosaur
                              <> matchInPlay
                              <> matchController controller

--- a/test/AddEffect.hs
+++ b/test/AddEffect.hs
@@ -1,0 +1,14 @@
+module AddEffect where
+
+import TestPrelude.V3
+
+test_AddEffect = testGroup "addEffect"
+  [ prove "adding effects changes the card in line with layer system" $ do
+      withLocation Play $ do
+        addCreature (1, 1) "Soldier"
+
+      addEffect (effectPTAdjust (2, 2)) "Soldier"
+      addEffect (effectPTSet (3, 3)) "Soldier"
+
+      validate (matchStrength (5, 5)) "Soldier"
+  ]

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -1,12 +1,12 @@
 module Effects where
 
-import TestPrelude.V2
+import TestPrelude.V3
 
 test_Effects = testGroup "V3 effects" $
   [ testGroup "assorted cards"
     [ prove "Effects only apply when enabled" $ do
         withLocation Hand $ do
-          withEffectV3
+          withEffect
             (pure $ matchAttribute creature)
             [ effectPTSet (1, 1)
             ]
@@ -21,7 +21,7 @@ test_Effects = testGroup "V3 effects" $
         let sliver = "sliver"
         withLocation Play $ do
           withAttribute sliver $
-            withEffectV3
+            withEffect
               (pure $ matchAttribute sliver <> matchInPlay)
               [ effectPTAdjustmentF . const $ do
                   self <- askSelf
@@ -96,7 +96,7 @@ test_Effects = testGroup "V3 effects" $
 
     , prove "Commander's Plate" $ do
         withLocation Play $
-          withEffectV3
+          withEffect
             (do
               ts <- viewSelf cardTargets
               return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
@@ -123,7 +123,7 @@ test_Effects = testGroup "V3 effects" $
     [ prove "Humble & Godhead of Awe" $ do
         withLocation Play $ do
           addCreature (2, 2) "Grizzly Bear"
-          withEffectV3
+          withEffect
             (matchOtherCreatures <$> askSelf)
             [ effectPTSet (1, 1)
             ]
@@ -144,7 +144,7 @@ test_Effects = testGroup "V3 effects" $
             throwError "Did not remove ability"
     , prove "Humility & Opalescence" $ do
         withLocation Play $ do
-          withCMC 4 $ withEffectV3
+          withCMC 4 $ withEffect
             (pure $ matchAttribute creature)
             [ effectPTSet (0, 1)
             , effectNoAbilities
@@ -152,7 +152,7 @@ test_Effects = testGroup "V3 effects" $
             "Each creature loses all abilities and is 0/1" $
               addEnchantment "Humility"
 
-          withCMC 4 $ withEffectV3
+          withCMC 4 $ withEffect
             (matchOther enchantment <$> askSelf)
             [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc))
             , effectType creature
@@ -166,14 +166,14 @@ test_Effects = testGroup "V3 effects" $
             throwError "Did not make Humility a 4/4"
     , prove "Opalescence & Humility" $ do
         withLocation Play $ do
-          withCMC 4 $ withEffectV3
+          withCMC 4 $ withEffect
             (matchOther enchantment <$> askSelf)
             [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc)) , effectType creature
             ]
             "Other enchanments are creatures with P/T equal to CMC" $
               addEnchantment "Opalescence"
 
-          withCMC 4 $ withEffectV3
+          withCMC 4 $ withEffect
            (pure $ matchAttribute creature)
            [ effectPTSet (0, 1)
            , effectNoAbilities

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -23,7 +23,7 @@ test_Effects = testGroup "V3 effects" $
           withAttribute sliver $
             withEffect
               (pure $ matchAttribute sliver <> matchInPlay)
-              [ effectPTAdjustmentF . const $ do
+              [ effectPTAdjustF . const $ do
                   self <- askSelf
                   slivers <- length <$> askCards (
                                              matchAttribute sliver
@@ -75,7 +75,7 @@ test_Effects = testGroup "V3 effects" $
               return $ length dinos > 0
             )
             (matchCard <$> askSelf)
-            [ effectPTAdjustment (2, 2)
+            [ effectPTAdjust (2, 2)
             ]
             "+2/+2 so long as you control another dinosaur"
               $ addCreature (1, 1) "Drover of the Mighty"
@@ -101,7 +101,7 @@ test_Effects = testGroup "V3 effects" $
     --          ts <- viewSelf cardTargets
     --          return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
     --        )
-    --        [ effectPTAdjustment (3, 3)
+    --        [ effectPTAdjust (3, 3)
     --        , effectProtectionF (
     --            const $ do
     --              --owner <- viewSelf cardOwner

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -55,7 +55,7 @@ test_Effects = testGroup "V3 effects" $
         withLocation Play $ do
           withEffectWhen
             (do
-              controller <- viewSelf cardOwner
+              controller <- viewSelf cardController
               dinos <- askCards $ matchAttribute dinosaur
                                <> matchInPlay
                                <> matchController controller

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -1,0 +1,80 @@
+module Effects where
+
+import TestPrelude.V2
+
+import qualified Data.Set as S
+
+-- https://blogs.magicjudges.org/ftw/l2-prep/rules-and-policy/continuous-effects/
+test_Effects = testGroup "effects (magic judges examples)"
+  [ prove "Humble & Godhead of Awe" $ do
+      withLocation Play $ do
+        addCreature (2, 2) "Grizzly Bear"
+        withEffectV3
+          (pure True) -- TODO card matcher?
+          (matchOtherCreatures <$> askSelf)
+          (const . pure $ effectPTSet 1 1)
+          "Other creatures are 1/1" $ do
+            addCreature (4, 4) "Godhead of Awe"
+
+        c <- requireCard "Grizzly Bear" mempty
+
+        unless (view cardStrength c == mkStrength (1, 1)) $
+          throwError "Did not apply 1/1 effect"
+
+        addEffect (effectPTSet 0 1 <> effectNoAbilities) "Godhead of Awe"
+
+        c <- requireCard "Grizzly Bear" mempty
+
+        unless (view cardStrength c == mkStrength (2, 2)) $
+          throwError "Did not remove ability"
+  , prove "Humility & Opalescence" $ do
+      withLocation Play $ do
+        withEffectV3
+         (pure True)
+         (pure $ matchAttribute creature)
+         (const . pure $ effectPTSet 0 1 <> effectNoAbilities)
+         "Each creature loses all abilities and is 1/1" $
+           addEnchantment "Humility"
+
+        withEffectV3
+          (pure True)
+          (matchOther enchantment <$> askSelf)
+          (\c -> do
+            let cmc = view cardCmc c
+
+            return $ effectPTSet cmc cmc <> effectType creature
+          )
+          "Other enchanments are creatures with P/T equal to CMC" $
+            addEnchantment "Opalescence"
+
+        c <- requireCard "Humility" mempty
+
+        -- TODO: Test reverse timestamp order as well
+        unless (view cardStrength c == mkStrength (4, 4)) $
+          throwError "Did not make Humility a 4/4"
+  , prove "Commander's Plate" $ do
+      withLocation Play $
+        withEffectV3
+          (pure True)
+          (do
+            ts <- viewSelf cardTargets
+            return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
+          )
+          (const $ do
+            --owner <- viewSelf cardOwner
+            commanders <- askCards $ matchAttribute "commander" -- <> matchOwner owner
+
+            let colors = S.toList
+                         $ foldr (<>) mempty
+                         . map (view cardColors)
+                         $ commanders :: [Color]
+            -- TODO: Need to invert color list!
+            let proEffect = foldr (<>) mempty
+                            . map effectProtection
+                            $ colors
+
+            return (proEffect <> effectPTAdjustment 3 3)
+          )
+          "+3/+3 and pro commander colors" $
+            addArtifact "Commander's Plate"
+  ]

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -7,7 +7,6 @@ test_Effects = testGroup "V3 effects" $
     [ prove "Effects only apply when enabled" $ do
         withLocation Hand $ do
           withEffectV3
-            enabledInPlay
             (pure $ matchAttribute creature)
             [ effectPTSet (1, 1)
             ]
@@ -23,7 +22,6 @@ test_Effects = testGroup "V3 effects" $
         withLocation Play $ do
           withAttribute sliver $
             withEffectV3
-              enabledInPlay
               (pure $ matchAttribute sliver <> matchInPlay)
               [ effectPTAdjustmentF . const $ do
                   self <- askSelf
@@ -67,7 +65,7 @@ test_Effects = testGroup "V3 effects" $
           withAttribute dinosaur $ addCreature (4, 4) "Dinosaur Hand"
 
         withLocation Play $ do
-          withEffectV3
+          withEffectWhen
             (do
               controller <- viewSelf cardOwner
               dinos <- askCards $ matchAttribute dinosaur
@@ -99,7 +97,6 @@ test_Effects = testGroup "V3 effects" $
     , prove "Commander's Plate" $ do
         withLocation Play $
           withEffectV3
-            enabledInPlay
             (do
               ts <- viewSelf cardTargets
               return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
@@ -127,7 +124,6 @@ test_Effects = testGroup "V3 effects" $
         withLocation Play $ do
           addCreature (2, 2) "Grizzly Bear"
           withEffectV3
-            enabledInPlay
             (matchOtherCreatures <$> askSelf)
             [ effectPTSet (1, 1)
             ]
@@ -149,7 +145,6 @@ test_Effects = testGroup "V3 effects" $
     , prove "Humility & Opalescence" $ do
         withLocation Play $ do
           withCMC 4 $ withEffectV3
-            enabledInPlay
             (pure $ matchAttribute creature)
             [ effectPTSet (0, 1)
             , effectNoAbilities
@@ -158,7 +153,6 @@ test_Effects = testGroup "V3 effects" $
               addEnchantment "Humility"
 
           withCMC 4 $ withEffectV3
-            enabledInPlay
             (matchOther enchantment <$> askSelf)
             [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc))
             , effectType creature
@@ -173,7 +167,6 @@ test_Effects = testGroup "V3 effects" $
     , prove "Opalescence & Humility" $ do
         withLocation Play $ do
           withCMC 4 $ withEffectV3
-            enabledInPlay
             (matchOther enchantment <$> askSelf)
             [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc)) , effectType creature
             ]
@@ -181,7 +174,6 @@ test_Effects = testGroup "V3 effects" $
               addEnchantment "Opalescence"
 
           withCMC 4 $ withEffectV3
-           (pure True)
            (pure $ matchAttribute creature)
            [ effectPTSet (0, 1)
            , effectNoAbilities

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -92,31 +92,6 @@ test_Effects = testGroup "V3 effects" $
 
         unless (view cardStrength c == mkStrength (3, 3)) $
           throwError "Should be a 3/3"
-
-
-    --, prove "Commander's Plate" $ do
-    --    withLocation Play $
-    --      withEffect
-    --        (do
-    --          ts <- viewSelf cardTargets
-    --          return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
-    --        )
-    --        [ effectPTAdjust (3, 3)
-    --        , effectProtectionF (
-    --            const $ do
-    --              --owner <- viewSelf cardOwner
-    --              commanders <- askCards $ matchAttribute "commander" -- <> matchOwner owner
-
-    --              -- TODO: Need to invert color list!
-    --              let colors =   foldr (<>) mempty
-    --                           . map (view cardColors)
-    --                           $ commanders
-
-    --              return colors
-    --          )
-    --          ]
-    --        "+3/+3 and pro commander colors" $
-    --          addArtifact "Commander's Plate"
     ]
   -- https://blogs.magicjudges.org/ftw/l2-prep/rules-and-policy/continuous-effects/
   , testGroup "effects (magic judges examples)"

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -94,29 +94,29 @@ test_Effects = testGroup "V3 effects" $
           throwError "Should be a 3/3"
 
 
-    , prove "Commander's Plate" $ do
-        withLocation Play $
-          withEffect
-            (do
-              ts <- viewSelf cardTargets
-              return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
-            )
-            [ effectPTAdjustment (3, 3)
-            , effectProtectionF (
-                const $ do
-                  --owner <- viewSelf cardOwner
-                  commanders <- askCards $ matchAttribute "commander" -- <> matchOwner owner
+    --, prove "Commander's Plate" $ do
+    --    withLocation Play $
+    --      withEffect
+    --        (do
+    --          ts <- viewSelf cardTargets
+    --          return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
+    --        )
+    --        [ effectPTAdjustment (3, 3)
+    --        , effectProtectionF (
+    --            const $ do
+    --              --owner <- viewSelf cardOwner
+    --              commanders <- askCards $ matchAttribute "commander" -- <> matchOwner owner
 
-                  -- TODO: Need to invert color list!
-                  let colors =   foldr (<>) mempty
-                               . map (view cardColors)
-                               $ commanders
+    --              -- TODO: Need to invert color list!
+    --              let colors =   foldr (<>) mempty
+    --                           . map (view cardColors)
+    --                           $ commanders
 
-                  return colors
-              )
-              ]
-            "+3/+3 and pro commander colors" $
-              addArtifact "Commander's Plate"
+    --              return colors
+    --          )
+    --          ]
+    --        "+3/+3 and pro commander colors" $
+    --          addArtifact "Commander's Plate"
     ]
   -- https://blogs.magicjudges.org/ftw/l2-prep/rules-and-policy/continuous-effects/
   , testGroup "effects (magic judges examples)"
@@ -155,7 +155,7 @@ test_Effects = testGroup "V3 effects" $
           withCMC 4 $ withEffect
             (matchOther enchantment <$> askSelf)
             [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc))
-            , effectType creature
+            , effectAddType creature
             ]
             "Other enchanments are creatures with P/T equal to CMC" $
               addEnchantment "Opalescence"
@@ -168,7 +168,7 @@ test_Effects = testGroup "V3 effects" $
         withLocation Play $ do
           withCMC 4 $ withEffect
             (matchOther enchantment <$> askSelf)
-            [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc)) , effectType creature
+            [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc)) , effectAddType creature
             ]
             "Other enchanments are creatures with P/T equal to CMC" $
               addEnchantment "Opalescence"

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -117,7 +117,7 @@ test_Effects = testGroup "V3 effects" $
         withLocation Play $ do
           withCMC 4 $ withEffect
             (matchOther enchantment <$> askSelf)
-            [ effectPTSetF (\c -> let cmc = view cardCmc c inreturn (cmc, cmc))
+            [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc))
             , effectAddType creature
             ]
             "Other enchanments are creatures with P/T equal to CMC" $

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -13,10 +13,8 @@ test_Effects = testGroup "V3 effects" $
             "Creatures are 1/1" $ do
               addCreature (4, 4) "Some Creature"
 
-          c <- requireCard "Some Creature" mempty
+          validate (matchStrength (4, 4)) "Some Creature"
 
-          unless (view cardStrength c == mkStrength (4, 4)) $
-            throwError "Applied effect when disabled"
     , prove "Sliver Legion" $ do
         let sliver = "sliver"
         withLocation Play $ do
@@ -35,24 +33,14 @@ test_Effects = testGroup "V3 effects" $
               "All Slivers get +1/+1 for each other Sliver"
                 $ addCreature (7, 7) "Sliver Legion"
 
-          c <- requireCard "Sliver Legion" mempty
-
-          unless (view cardStrength c == mkStrength (7, 7)) $
-            throwError "No other slivers yet, should be 7/7"
+          validate (matchStrength (7, 7)) "Sliver Legion"
 
           withLocation Play $ do
             withAttribute sliver $ addCreature (2, 2) "Sliver 1"
             withAttribute sliver $ addCreature (2, 2) "Sliver 2"
 
-          c <- requireCard "Sliver Legion" mempty
-
-          unless (view cardStrength c == mkStrength (9, 9)) $
-            throwError "Should get +2/+2 from other slivers"
-
-          c <- requireCard "Sliver 1" mempty
-
-          unless (view cardStrength c == mkStrength (4, 4)) $
-            throwError "Should get +2/+2 from other slivers"
+          validate (matchStrength (9, 9)) "Sliver Legion"
+          validate (matchStrength (4, 4)) "Sliver 1"
 
     , prove "Drover of the Mighty" $ do
         let dinosaur = "dinosaur"
@@ -80,18 +68,12 @@ test_Effects = testGroup "V3 effects" $
             "+2/+2 so long as you control another dinosaur"
               $ addCreature (1, 1) "Drover of the Mighty"
 
-        c <- requireCard "Drover of the Mighty" mempty
-
-        unless (view cardStrength c == mkStrength (1, 1)) $
-          throwError "Should still be a 1/1, no dinos"
+        validate (matchStrength (1, 1)) "Drover of the Mighty"
 
         withLocation Play $ do
           withAttribute dinosaur $ addCreature (4, 4) "Dinosaur"
 
-        c <- requireCard "Drover of the Mighty" mempty
-
-        unless (view cardStrength c == mkStrength (3, 3)) $
-          throwError "Should be a 3/3"
+        validate (matchStrength (3, 3)) "Drover of the Mighty"
     ]
   -- https://blogs.magicjudges.org/ftw/l2-prep/rules-and-policy/continuous-effects/
   , testGroup "effects (magic judges examples)"
@@ -105,18 +87,12 @@ test_Effects = testGroup "V3 effects" $
             "Other creatures are 1/1" $ do
               addCreature (4, 4) "Godhead of Awe"
 
-          c <- requireCard "Grizzly Bear" mempty
-
-          unless (view cardStrength c == mkStrength (1, 1)) $
-            throwError "Did not apply 1/1 effect"
+          validate (matchStrength (1, 1)) "Grizzly Bear"
 
           addEffect (effectPTSet (0, 1)) "Godhead of Awe"
           addEffect (effectNoAbilities) "Godhead of Awe"
 
-          c <- requireCard "Grizzly Bear" mempty
-
-          unless (view cardStrength c == mkStrength (2, 2)) $
-            throwError "Did not remove ability"
+          validate (matchStrength (2, 2)) "Grizzly Bear"
     , prove "Humility & Opalescence" $ do
         withLocation Play $ do
           withCMC 4 $ withEffect
@@ -135,15 +111,14 @@ test_Effects = testGroup "V3 effects" $
             "Other enchanments are creatures with P/T equal to CMC" $
               addEnchantment "Opalescence"
 
-          c <- requireCard "Humility" mempty
+          validate (matchStrength (4, 4)) "Humility"
 
-          unless (view cardStrength c == mkStrength (4, 4)) $
-            throwError "Did not make Humility a 4/4"
     , prove "Opalescence & Humility" $ do
         withLocation Play $ do
           withCMC 4 $ withEffect
             (matchOther enchantment <$> askSelf)
-            [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc)) , effectAddType creature
+            [ effectPTSetF (\c -> let cmc = view cardCmc c inreturn (cmc, cmc))
+            , effectAddType creature
             ]
             "Other enchanments are creatures with P/T equal to CMC" $
               addEnchantment "Opalescence"
@@ -156,10 +131,6 @@ test_Effects = testGroup "V3 effects" $
            "Each creature loses all abilities and is 0/1" $
              addEnchantment "Humility"
 
-
-          c <- requireCard "Humility" mempty
-
-          unless (view cardStrength c == mkStrength (0, 1)) $
-            throwError "Did not make Humility a 0/1"
+          validate (matchStrength (0, 1)) "Humility"
     ]
   ]

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -10,7 +10,7 @@ test_Effects = testGroup "V3 effects" $
     [ prove "Effects only apply when enabled" $ do
         withLocation Hand $ do
           withEffectV3
-            (applyMatcher matchInPlay <$> askSelf)
+            enabledInPlay
             (pure $ matchAttribute creature)
             [ effectPTSet (1, 1)
             ]
@@ -26,7 +26,7 @@ test_Effects = testGroup "V3 effects" $
         withLocation Play $ do
           withAttribute sliver $
             withEffectV3
-              (applyMatcher matchInPlay <$> askSelf)
+              enabledInPlay
               (pure $ matchAttribute sliver <> matchInPlay)
               [ effectPTAdjustmentF . const $ do
                   self <- askSelf
@@ -102,7 +102,7 @@ test_Effects = testGroup "V3 effects" $
     , prove "Commander's Plate" $ do
         withLocation Play $
           withEffectV3
-            (applyMatcher matchInPlay <$> askSelf)
+            enabledInPlay
             (do
               ts <- viewSelf cardTargets
               return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
@@ -129,7 +129,7 @@ test_Effects = testGroup "V3 effects" $
         withLocation Play $ do
           addCreature (2, 2) "Grizzly Bear"
           withEffectV3
-            (applyMatcher matchInPlay <$> askSelf)
+            enabledInPlay
             (matchOtherCreatures <$> askSelf)
             [ effectPTSet (1, 1)
             ]
@@ -151,7 +151,7 @@ test_Effects = testGroup "V3 effects" $
     , prove "Humility & Opalescence" $ do
         withLocation Play $ do
           withCMC 4 $ withEffectV3
-            (applyMatcher matchInPlay <$> askSelf)
+            enabledInPlay
             (pure $ matchAttribute creature)
             [ effectPTSet (0, 1)
             , effectNoAbilities
@@ -160,7 +160,7 @@ test_Effects = testGroup "V3 effects" $
               addEnchantment "Humility"
 
           withCMC 4 $ withEffectV3
-            (applyMatcher matchInPlay <$> askSelf)
+            enabledInPlay
             (matchOther enchantment <$> askSelf)
             [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc))
             , effectType creature
@@ -175,7 +175,7 @@ test_Effects = testGroup "V3 effects" $
     , prove "Opalescence & Humility" $ do
         withLocation Play $ do
           withCMC 4 $ withEffectV3
-            (applyMatcher matchInPlay <$> askSelf)
+            enabledInPlay
             (matchOther enchantment <$> askSelf)
             [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc)) , effectType creature
             ]

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -2,11 +2,8 @@ module Effects where
 
 import TestPrelude.V2
 
-import qualified Data.Set as S
-
--- https://blogs.magicjudges.org/ftw/l2-prep/rules-and-policy/continuous-effects/
 test_Effects = testGroup "V3 effects" $
-  [ testGroup ""
+  [ testGroup "assorted cards"
     [ prove "Effects only apply when enabled" $ do
         withLocation Hand $ do
           withEffectV3
@@ -124,6 +121,7 @@ test_Effects = testGroup "V3 effects" $
             "+3/+3 and pro commander colors" $
               addArtifact "Commander's Plate"
     ]
+  -- https://blogs.magicjudges.org/ftw/l2-prep/rules-and-policy/continuous-effects/
   , testGroup "effects (magic judges examples)"
     [ prove "Humble & Godhead of Awe" $ do
         withLocation Play $ do

--- a/test/Effects.hs
+++ b/test/Effects.hs
@@ -5,100 +5,118 @@ import TestPrelude.V2
 import qualified Data.Set as S
 
 -- https://blogs.magicjudges.org/ftw/l2-prep/rules-and-policy/continuous-effects/
-test_Effects = testGroup "effects (magic judges examples)"
-  [ prove "Humble & Godhead of Awe" $ do
-      withLocation Play $ do
-        addCreature (2, 2) "Grizzly Bear"
-        withEffectV3
-          (pure True) -- TODO card matcher?
-          (matchOtherCreatures <$> askSelf)
-          [ effectPTSet (1, 1)
-          ]
-          "Other creatures are 1/1" $ do
-            addCreature (4, 4) "Godhead of Awe"
-
-        c <- requireCard "Grizzly Bear" mempty
-
-        unless (view cardStrength c == mkStrength (1, 1)) $
-          throwError "Did not apply 1/1 effect"
-
-        addEffect (effectPTSet (0, 1)) "Godhead of Awe"
-        addEffect (effectNoAbilities) "Godhead of Awe"
-
-        c <- requireCard "Grizzly Bear" mempty
-
-        unless (view cardStrength c == mkStrength (2, 2)) $
-          throwError "Did not remove ability"
-  , prove "Humility & Opalescence" $ do
-      withLocation Play $ do
-        withCMC 4 $ withEffectV3
-         (pure True)
-         (pure $ matchAttribute creature)
-         [ effectPTSet (0, 1)
-         , effectNoAbilities
-         ]
-         "Each creature loses all abilities and is 0/1" $
-           addEnchantment "Humility"
-
-        withCMC 4 $ withEffectV3
-          (pure True)
-          (matchOther enchantment <$> askSelf)
-          [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc))
-          , effectType creature
-          ]
-          "Other enchanments are creatures with P/T equal to CMC" $
-            addEnchantment "Opalescence"
-
-        c <- requireCard "Humility" mempty
-
-        unless (view cardStrength c == mkStrength (4, 4)) $
-          throwError "Did not make Humility a 4/4"
-  , prove "Opalescence & Humility" $ do
-      withLocation Play $ do
-        withCMC 4 $ withEffectV3
-          (pure True)
-          (matchOther enchantment <$> askSelf)
-          [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc)) , effectType creature
-          ]
-          "Other enchanments are creatures with P/T equal to CMC" $
-            addEnchantment "Opalescence"
-
-        withCMC 4 $ withEffectV3
-         (pure True)
-         (pure $ matchAttribute creature)
-         [ effectPTSet (0, 1)
-         , effectNoAbilities
-         ]
-         "Each creature loses all abilities and is 0/1" $
-           addEnchantment "Humility"
-
-
-        c <- requireCard "Humility" mempty
-
-        unless (view cardStrength c == mkStrength (0, 1)) $
-          throwError "Did not make Humility a 0/1"
-  , prove "Commander's Plate" $ do
-      withLocation Play $
-        withEffectV3
-          (pure True)
-          (do
-            ts <- viewSelf cardTargets
-            return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
-          )
-          [ effectPTAdjustment (3, 3)
-          , effectProtectionF (
-              const $ do
-                --owner <- viewSelf cardOwner
-                commanders <- askCards $ matchAttribute "commander" -- <> matchOwner owner
-
-                -- TODO: Need to invert color list!
-                let colors =   foldr (<>) mempty
-                             . map (view cardColors)
-                             $ commanders
-
-                return colors
-            )
+test_Effects = testGroup "V3 effects" $
+  [ testGroup ""
+    [ prove "Effects only apply when enabled" $ do
+        withLocation Hand $ do
+          withEffectV3
+            (applyMatcher matchInPlay <$> askSelf)
+            (pure $ matchAttribute creature)
+            [ effectPTSet (1, 1)
             ]
-          "+3/+3 and pro commander colors" $
-            addArtifact "Commander's Plate"
+            "Creatures are 1/1" $ do
+              addCreature (4, 4) "Some Creature"
+
+          c <- requireCard "Some Creature" mempty
+
+          unless (view cardStrength c == mkStrength (4, 4)) $
+            throwError "Applied effect when disabled"
+    , prove "Commander's Plate" $ do
+        withLocation Play $
+          withEffectV3
+            (applyMatcher matchInPlay <$> askSelf)
+            (do
+              ts <- viewSelf cardTargets
+              return $ foldl (\a v -> a `matchOr` (matchTarget v)) mempty ts
+            )
+            [ effectPTAdjustment (3, 3)
+            , effectProtectionF (
+                const $ do
+                  --owner <- viewSelf cardOwner
+                  commanders <- askCards $ matchAttribute "commander" -- <> matchOwner owner
+
+                  -- TODO: Need to invert color list!
+                  let colors =   foldr (<>) mempty
+                               . map (view cardColors)
+                               $ commanders
+
+                  return colors
+              )
+              ]
+            "+3/+3 and pro commander colors" $
+              addArtifact "Commander's Plate"
+    ]
+  , testGroup "effects (magic judges examples)"
+    [ prove "Humble & Godhead of Awe" $ do
+        withLocation Play $ do
+          addCreature (2, 2) "Grizzly Bear"
+          withEffectV3
+            (applyMatcher matchInPlay <$> askSelf)
+            (matchOtherCreatures <$> askSelf)
+            [ effectPTSet (1, 1)
+            ]
+            "Other creatures are 1/1" $ do
+              addCreature (4, 4) "Godhead of Awe"
+
+          c <- requireCard "Grizzly Bear" mempty
+
+          unless (view cardStrength c == mkStrength (1, 1)) $
+            throwError "Did not apply 1/1 effect"
+
+          addEffect (effectPTSet (0, 1)) "Godhead of Awe"
+          addEffect (effectNoAbilities) "Godhead of Awe"
+
+          c <- requireCard "Grizzly Bear" mempty
+
+          unless (view cardStrength c == mkStrength (2, 2)) $
+            throwError "Did not remove ability"
+    , prove "Humility & Opalescence" $ do
+        withLocation Play $ do
+          withCMC 4 $ withEffectV3
+            (applyMatcher matchInPlay <$> askSelf)
+            (pure $ matchAttribute creature)
+            [ effectPTSet (0, 1)
+            , effectNoAbilities
+            ]
+            "Each creature loses all abilities and is 0/1" $
+              addEnchantment "Humility"
+
+          withCMC 4 $ withEffectV3
+            (applyMatcher matchInPlay <$> askSelf)
+            (matchOther enchantment <$> askSelf)
+            [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc))
+            , effectType creature
+            ]
+            "Other enchanments are creatures with P/T equal to CMC" $
+              addEnchantment "Opalescence"
+
+          c <- requireCard "Humility" mempty
+
+          unless (view cardStrength c == mkStrength (4, 4)) $
+            throwError "Did not make Humility a 4/4"
+    , prove "Opalescence & Humility" $ do
+        withLocation Play $ do
+          withCMC 4 $ withEffectV3
+            (applyMatcher matchInPlay <$> askSelf)
+            (matchOther enchantment <$> askSelf)
+            [ effectPTSetF (\c -> let cmc = view cardCmc c in return (cmc, cmc)) , effectType creature
+            ]
+            "Other enchanments are creatures with P/T equal to CMC" $
+              addEnchantment "Opalescence"
+
+          withCMC 4 $ withEffectV3
+           (pure True)
+           (pure $ matchAttribute creature)
+           [ effectPTSet (0, 1)
+           , effectNoAbilities
+           ]
+           "Each creature loses all abilities and is 0/1" $
+             addEnchantment "Humility"
+
+
+          c <- requireCard "Humility" mempty
+
+          unless (view cardStrength c == mkStrength (0, 1)) $
+            throwError "Did not make Humility a 0/1"
+    ]
   ]

--- a/test/TestPrelude/V3.hs
+++ b/test/TestPrelude/V3.hs
@@ -1,0 +1,9 @@
+module TestPrelude.V3
+  ( module TestPrelude.V2
+  , module Dovin.V3
+  ) where
+
+import Dovin.V3
+import TestPrelude.V2 hiding
+  ( withEffect
+  )


### PR DESCRIPTION
This PR upgrades the effects system to make it more expressive, while also aligning more closely to the layer system as described in the official rules.

TODO:

* [x] Change V2 API to use `Identity` instead of `GameMonad` for the action. This is technically not backwards compatible, but no known cases actually require `GameMonad` so making the tradeoff to simplify the code.
* [x] Convert V2 effects to V3 while preserving V2 API (requires the `Identity` change above).
* [x] Introduce `Dovin.V3` namespace and export `withEffectsV3` as `withEffects`.
* [x] Introduce `Dovin.TestPrelude.V3` as well.
* [x] Move effects code into own file? Make the `Pile` types local to that file.
* [x] Use default `enabledInPlay` for `withEffect` and add `withEffectWhen` for custom
* [x] Remove `leEnabled` from data structure and fold it into `leAppliesTo`.
* [x] Update War of the Spark 2 to use new effects system for Drover (also update README)
* [x] Move counter handling into Layer system.
* [x] Consider a toggle to make V2 & V3 effects mutually exclusive to avoid accidental inter-dependency. [not needed with conversion to `Identity` monad]
* [x] Finish the Commander's Plate test case
* [x] Check the docs
* [ ] Bump version and push new package
* [x] Separate `cardOwner` from location. Not directly relevant to this PR, but has been used in some example cards and is a relatively simple change.
* [x] Rename `effectPTAdjustment` to `effectPTAdjust`