### PR TITLE
Solution for Commander Legends, plus a heap of other upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ solution = do
 formatter :: Step -> Formatter
 formatter step = case view stepNumber step of
   1 -> manaFormatter
-    <> cardFormatter "opponent creatures" (matchLocation (Opponent, Play))
+    <> cardFormatter "opponent creatures"
+         (matchController Opponent <> matchZone Play)
   _ -> boardFormatter
 
 manaFormatter = attributeFormatter $ do
@@ -112,6 +113,9 @@ solutions for published Possibility Storm puzzles!)
 * `ChannelFireball` automatically calculates High Tide mana.
 * `WarOfTheSpark2` shows how to define effects that depend on attributes of
   other cards.
+* `CommanderLegends` shows a large number of techniques: multiplayer, control
+  changing, equipment and aura effects, color protection, counters for dynamic
+  token generation, and more.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ solution = do
   step "Initial state" $ do
     as Opponent $ setLife 3
 
-    withLocation Hand $ addInstant "Plummet"
-    withLocation Play $ do
+    withZone Hand $ addInstant "Plummet"
+    withZone Play $ do
       addLands 2 "Forest"
 
     as Opponent $ do
-      withLocation Play $ do
+      withZone Play $ do
         withAttributes [flying, token] $ addCreature (4, 4) "Angel"
         withAttributes [flying]
           $ withEffect

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,13 +3,12 @@ module Main where
 import Control.Monad (forM_)
 import Dovin
 
---import qualified Solutions
-import Solutions.CommanderLegends
+import qualified Solutions
 
 main :: IO ()
-main = run formatter solution
---main = runAll
+--main = run formatter solution
+main = runAll
 
---runAll =
---  forM_ Solutions.all $ \(name, solution, formatter) ->
---    run formatter solution
+runAll =
+  forM_ Solutions.all $ \(name, solution, formatter) ->
+    run formatter solution

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,12 +3,13 @@ module Main where
 import Control.Monad (forM_)
 import Dovin
 
-import qualified Solutions
+--import qualified Solutions
+import Solutions.CommanderLegends
 
 main :: IO ()
---main = run formatter solution
-main = runAll
+main = run formatter solution
+--main = runAll
 
-runAll =
-  forM_ Solutions.all $ \(name, solution, formatter) ->
-    run formatter solution
+--runAll =
+--  forM_ Solutions.all $ \(name, solution, formatter) ->
+--    run formatter solution

--- a/src/Dovin.hs
+++ b/src/Dovin.hs
@@ -1,5 +1,5 @@
 module Dovin
-  ( module Dovin.V3
+  ( module Dovin.V4
   ) where
 
-import Dovin.V3
+import Dovin.V4

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -512,7 +512,7 @@ move from to name = action "move" $ do
   c <- requireCard name $ matchLocation from
 
   when (from == to) $
-    throwError "cannot move to same location"
+    throwError $ "cannot move to same location: " <> show from
 
   when (snd to == Stack) $
     throwError "cannot move directly to stack"
@@ -543,8 +543,9 @@ move from to name = action "move" $ do
       moveTo Exile name
   else if snd from == Play && snd to == Graveyard && view cardPlusOneCounters c == 0 && hasAttribute undying c then
     modifyCardDeprecated name cardPlusOneCounters (+ 1)
-  else
+  else do
     modifyCardDeprecated name location (const to)
+    modifyCardDeprecated name cardZone (const (snd to))
 
 -- | Target a permanent.
 --

--- a/src/Dovin/Actions.hs
+++ b/src/Dovin/Actions.hs
@@ -803,7 +803,7 @@ damage f t source = action "damage" $ do
 
   damage' dmg t c
   when (hasAttribute lifelink c) $
-    modifying (life . at (view cardController $ c) . non 0) (+ dmg)
+    modifying (life . at (view cardController c) . non 0) (+ dmg)
   resolveEffects
 
   where

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -43,7 +43,6 @@ import Dovin.Matchers (matchNone)
 import Dovin.Effects (resolveEffects, enabledInPlay)
 
 import Control.Monad.Reader (local)
-import Control.Lens (_2)
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
 
@@ -159,20 +158,16 @@ withLocation loc m = do
   p <- view envActor
 
   local (
-        set (envTemplate . cardLocation) (p, loc)
-      . set (envTemplate . cardController) p
+        set (envTemplate . cardController) p
       . set (envTemplate . cardZone) loc
     ) m
 
 -- | Place the created card into a specific zone.
 withZone :: Zone -> GameMonad () -> GameMonad ()
 withZone n =
-  local (
-      set (envTemplate . cardZone) n
-    . set (envTemplate . cardLocation . _2) n
-    )
+  local (set (envTemplate . cardZone) n)
 
--- | Set the target for the created card.
+-- | Add a target to the created card.
 withCardTarget :: CardName -> GameMonad () -> GameMonad ()
 withCardTarget target = local (over (envTemplate . cardTargets) ((:) (TargetCard target)))
 

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -31,7 +31,8 @@ module Dovin.Builder (
   , withOwner
   , withPlusOneCounters
   , withMinusOneCounters
-  , withTarget
+  , withCardTarget
+  , withColors
   ) where
 
 import Dovin.Attributes
@@ -164,8 +165,12 @@ withOwner :: Player -> GameMonad () -> GameMonad ()
 withOwner = local . set envOwner . Just
 
 -- | Set the target for the created card.
-withTarget :: Target -> GameMonad () -> GameMonad ()
-withTarget target = local (over (envTemplate . cardTargets) ((:) target))
+withCardTarget :: CardName -> GameMonad () -> GameMonad ()
+withCardTarget target = local (over (envTemplate . cardTargets) ((:) (TargetCard target)))
+
+withColors :: [Color] -> GameMonad () -> GameMonad ()
+withColors cs m =
+  local (set (envTemplate . cardColors) (S.fromList cs)) m
 
 -- | Set the number of +1/+1 counters of the created card.
 withPlusOneCounters :: Int -> GameMonad () -> GameMonad ()

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -69,7 +69,7 @@ addAura :: CardName -> GameMonad ()
 addAura name = withAttribute aura $ addEnchantment name
 
 addArtifact :: CardName -> GameMonad ()
-addArtifact name = withAttribute artifact $ addEnchantment name
+addArtifact name = withAttribute artifact $ addCard name
 
 addCreature :: (Int, Int) -> CardName -> GameMonad ()
 addCreature strength name = local (set (envTemplate . cardStrength) $ mkStrength strength)

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -29,7 +29,6 @@ module Dovin.Builder (
   , withEffectWhen
   , withLocation
   , withZone
-  , withOwner
   , withPlusOneCounters
   , withMinusOneCounters
   , withCardTarget
@@ -57,7 +56,6 @@ addCard name = do
     Just _ -> throwError $ "Card should be removed: " <> name
     Nothing -> do
       template <- view envTemplate
-      owner <- view envOwner
       modifying cards (M.insert name (BaseCard
         $ set cardName name
         . set cardTimestamp now
@@ -101,7 +99,6 @@ as :: Player -> GameMonad () -> GameMonad ()
 as p = local (
     set envActor p
     . set (envTemplate . cardController) p
-    . set (envTemplate . cardOwner) p
   )
 
 -- | Add an attribute to the created card, as identified by a string.
@@ -174,11 +171,6 @@ withZone n =
       set (envTemplate . cardZone) n
     . set (envTemplate . cardLocation . _2) n
     )
-
--- | Set the owner for the created card. If not specified, defaults to the
--- owner of the card location.
-withOwner :: Player -> GameMonad () -> GameMonad ()
-withOwner = local . set envOwner . Just
 
 -- | Set the target for the created card.
 withCardTarget :: CardName -> GameMonad () -> GameMonad ()

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -31,6 +31,7 @@ module Dovin.Builder (
   , withOwner
   , withPlusOneCounters
   , withMinusOneCounters
+  , withTarget
   ) where
 
 import Dovin.Attributes
@@ -96,7 +97,7 @@ addSorcery name = withAttribute sorcery $ addCard name
 
 -- | Perform action as the specified player.
 as :: Player -> GameMonad () -> GameMonad ()
-as player = local (set envActor player)
+as = local . set envActor
 
 -- | Add an attribute to the created card, as identified by a string.
 -- Attributes with that special meaning to Dovin built-ins (such as flying) are
@@ -160,7 +161,11 @@ withLocation loc m = do
 -- | Set the owner for the created card. If not specified, defaults to the
 -- owner of the card location.
 withOwner :: Player -> GameMonad () -> GameMonad ()
-withOwner owner = local (set envOwner (Just owner))
+withOwner = local . set envOwner . Just
+
+-- | Set the target for the created card.
+withTarget :: Target -> GameMonad () -> GameMonad ()
+withTarget target = local (over (envTemplate . cardTargets) ((:) target))
 
 -- | Set the number of +1/+1 counters of the created card.
 withPlusOneCounters :: Int -> GameMonad () -> GameMonad ()

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -186,8 +186,8 @@ withCardTarget :: CardName -> GameMonad () -> GameMonad ()
 withCardTarget target = local (over (envTemplate . cardTargets) ((:) (TargetCard target)))
 
 withColors :: [Color] -> GameMonad () -> GameMonad ()
-withColors cs m =
-  local (set (envTemplate . cardColors) (S.fromList cs)) m
+withColors cs =
+  local (set (envTemplate . cardColors) (S.fromList cs))
 
 -- | Set the number of +1/+1 counters of the created card.
 withPlusOneCounters :: Int -> GameMonad () -> GameMonad ()

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -44,7 +44,7 @@ import Dovin.Matchers (matchNone)
 import Dovin.Effects (resolveEffects, enabledInPlay)
 
 import Control.Monad.Reader (local)
-import Control.Lens (_1, _2)
+import Control.Lens (_2)
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
 
@@ -61,7 +61,6 @@ addCard name = do
       modifying cards (M.insert name (BaseCard
         $ set cardName name
         . set cardTimestamp now
-        -- . set cardOwner (maybe (view (cardLocation . _1) template) id owner)
         $ template))
       resolveEffects
 

--- a/src/Dovin/Builder.hs
+++ b/src/Dovin/Builder.hs
@@ -43,8 +43,6 @@ import Dovin.Helpers (getTimestamp)
 import Dovin.Matchers (matchNone)
 import Dovin.Effects (resolveEffects, enabledInPlay)
 
-import Debug.Trace
-
 import Control.Monad.Reader (local)
 import Control.Lens (_1, _2)
 import qualified Data.HashMap.Strict as M
@@ -167,7 +165,7 @@ withLocation loc m = do
   local (
         set (envTemplate . cardLocation) (p, loc)
       . set (envTemplate . cardController) p
-      . set (envTemplate . cardZone) (trace (show loc) loc)
+      . set (envTemplate . cardZone) loc
     ) m
 
 -- | Place the created card into a specific zone.

--- a/src/Dovin/Effects.hs
+++ b/src/Dovin/Effects.hs
@@ -15,6 +15,7 @@ module Dovin.Effects
   , effectNoAbilities
   , effectAddAbility
   , effectAddType
+  , effectProtectionF
 
   , resolveEffects
 
@@ -79,6 +80,11 @@ effectNoAbilities = LayeredEffectPart Layer6 (pure . set cardPassiveEffects memp
 -- | Layer 4 effect to add a type to a card. Since card types are modeled
 -- explicitly, it instead adds a new 'CardAttribute'.
 effectAddType attr = LayeredEffectPart Layer4 (pure . over cardAttributes (S.insert attr))
+
+effectProtectionF :: (Card -> EffectMonad Colors) -> LayeredEffectPart
+effectProtectionF f = LayeredEffectPart Layer6 $ \c -> do
+                        cs <- f c
+                        return $ over cardProtection (cs <>) c
 
 -- | Effect enabled definition to apply when a card is in play.
 enabledInPlay :: EffectMonad Bool

--- a/src/Dovin/Effects.hs
+++ b/src/Dovin/Effects.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE Rank2Types #-}
 
 {-|
 Effects are continuous effects, such as "other creatures get +1/+1". Note that
@@ -14,7 +15,10 @@ module Dovin.Effects
   , effectPTAdjustF
   , effectNoAbilities
   , effectAddAbility
+  , effectAddAbilityF
   , effectAddType
+  , effectAddTypeF
+  , effectProtection
   , effectProtectionF
   , effectControl
   , effectControlF
@@ -33,7 +37,7 @@ import Dovin.Prelude
 import Dovin.Types
 import Dovin.Matchers (applyMatcher, matchInPlay)
 
-import Control.Lens (makeLenses, over, view, set)
+import Control.Lens (makeLenses, over, view, set, Lens')
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
 import Control.Monad.Reader (ask, runReader)
@@ -57,9 +61,7 @@ effectPTSet = effectPTSetF . const . pure
 
 -- | Layer 7B effect to set the power and toughness of a creature.
 effectPTSetF :: (Card -> EffectMonad (Int, Int)) -> LayeredEffectPart
-effectPTSetF f = LayeredEffectPart Layer7B $ \c -> do
-                   pt <- f c
-                   return $ set cardStrength (mkStrength pt) c
+effectPTSetF = effectF Layer7B cardStrength (const . mkStrength)
 
 -- | Constant variant of 'effectPTAdjustF'
 effectPTAdjust :: (Int, Int) -> LayeredEffectPart
@@ -67,33 +69,55 @@ effectPTAdjust = effectPTAdjustF . const . pure
 
 -- | Layer 7C effect to adjust the power and toughness of a creature.
 effectPTAdjustF :: (Card -> EffectMonad (Int, Int)) -> LayeredEffectPart
-effectPTAdjustF f = LayeredEffectPart Layer7C $ \c -> do
-                   pt <- f c
-                   return $ over cardStrength (mkStrength pt <>) c
+effectPTAdjustF = effectF Layer7C cardStrength ((<>) . mkStrength)
+
+-- | Constant variant of 'effectAddAbilityF'
+effectAddAbility = effectAddAbilityF . const . pure
 
 -- | Layer 6 effect to add an ability to a card. In practice, it adds adds a
 -- new 'CardAttribute'.
-effectAddAbility attr = LayeredEffectPart Layer6 (pure . over cardAttributes (S.insert attr))
+effectAddAbilityF = effectF Layer6 cardAttributes S.insert
 
 -- | Layer 6 effect to remove all abilities from a card. This doesn't
 -- temporary abilities added by 'addEffect'.
-effectNoAbilities = LayeredEffectPart Layer6 (pure . set cardPassiveEffects mempty)
+effectNoAbilities =
+  LayeredEffectPart Layer6 (pure . set cardPassiveEffects mempty)
+
+-- | Constant variant of effectAddTypeF
+effectAddType = effectAddTypeF . const . pure
 
 -- | Layer 4 effect to add a type to a card. Since card types are modeled
 -- explicitly, it instead adds a new 'CardAttribute'.
-effectAddType attr = LayeredEffectPart Layer4 (pure . over cardAttributes (S.insert attr))
+effectAddTypeF = effectF Layer4 cardAttributes S.insert
 
+-- | Constant variant of 'effectControlF'
+effectProtection = effectProtectionF . const . pure
+
+-- | Layer 6 effect to give a card protection from a color.
 effectProtectionF :: (Card -> EffectMonad Colors) -> LayeredEffectPart
-effectProtectionF f = LayeredEffectPart Layer6 $ \c -> do
-                        cs <- f c
-                        return $ over cardProtection (cs <>) c
+effectProtectionF = effectF Layer6 cardProtection (<>)
 
+-- | Constant variant of 'effectControlF'
 effectControl = effectControlF . const . pure
 
+-- | Layer 2 effect to change control of a card. Note that side-effects such as
+-- summoning sickness and removing from combat are not considered and must be
+-- handled manually.
 effectControlF :: (Card -> EffectMonad Player) -> LayeredEffectPart
-effectControlF f = LayeredEffectPart Layer2 $ \c -> do
-                     p <- f c
-                     return $ over cardController (const p) c
+effectControlF = effectF Layer2 cardController const
+
+-- Private builder function for effects that affect a single card attribute.
+effectF ::
+     Layer           -- ^ What layer the effect applies to
+  -> Lens' Card b    -- ^ Lens for the card attribute the effect modifies
+  -> (a -> (b -> b))         -- ^ Transform the value from the definition into
+                             -- a function to apply over the value in the lens
+  -> (Card -> EffectMonad a) -- ^ The effect definition
+  -> LayeredEffectPart
+effectF layer lens overF f =
+  LayeredEffectPart layer $ \c -> do
+    p <- f c
+    return $ over lens (overF p) c
 
 -- | Effect enabled definition to apply when a card is in play.
 enabledInPlay :: EffectMonad Bool

--- a/src/Dovin/Effects.hs
+++ b/src/Dovin/Effects.hs
@@ -16,6 +16,7 @@ module Dovin.Effects
   , effectAddAbility
   , effectAddType
   , effectProtectionF
+  , effectControlF
 
   , resolveEffects
 
@@ -85,6 +86,11 @@ effectProtectionF :: (Card -> EffectMonad Colors) -> LayeredEffectPart
 effectProtectionF f = LayeredEffectPart Layer6 $ \c -> do
                         cs <- f c
                         return $ over cardProtection (cs <>) c
+
+effectControlF :: (Card -> EffectMonad Player) -> LayeredEffectPart
+effectControlF f = LayeredEffectPart Layer2 $ \c -> do
+                     p <- f c
+                     return $ over cardController (const p) c
 
 -- | Effect enabled definition to apply when a card is in play.
 enabledInPlay :: EffectMonad Bool

--- a/src/Dovin/Effects.hs
+++ b/src/Dovin/Effects.hs
@@ -209,8 +209,6 @@ resolveCounters board =
           else
             Just $ effectPTAdjust (p, t)
 
-        dup x = (x, x)
-
 collectNewEffectsAtLayer :: Layer -> (Board, Pile) -> (Board, Pile)
 collectNewEffectsAtLayer layer (board, pile) =
   (

--- a/src/Dovin/Effects.hs
+++ b/src/Dovin/Effects.hs
@@ -16,6 +16,7 @@ module Dovin.Effects
   , effectAddAbility
   , effectAddType
   , effectProtectionF
+  , effectControl
   , effectControlF
 
   , resolveEffects
@@ -86,6 +87,8 @@ effectProtectionF :: (Card -> EffectMonad Colors) -> LayeredEffectPart
 effectProtectionF f = LayeredEffectPart Layer6 $ \c -> do
                         cs <- f c
                         return $ over cardProtection (cs <>) c
+
+effectControl = effectControlF . const . pure
 
 effectControlF :: (Card -> EffectMonad Player) -> LayeredEffectPart
 effectControlF f = LayeredEffectPart Layer2 $ \c -> do

--- a/src/Dovin/Formatting.hs
+++ b/src/Dovin/Formatting.hs
@@ -10,7 +10,6 @@ import Dovin.Types
 import Control.Monad.Writer (Writer, execWriter, tell)
 import Control.Lens (alongside)
 
-import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
 import Data.List (intercalate, sort, sortBy, nub)
 import Data.Ord (comparing)

--- a/src/Dovin/Formatting.hs
+++ b/src/Dovin/Formatting.hs
@@ -135,8 +135,6 @@ boardFormatter board =
     formatLocation (Active, Stack) = stackFormatter
     formatLocation l = cardFormatter (show l) (matchLocation l)
 
-dup x = (x, x)
-
 boardFormatter2 :: Formatter
 boardFormatter2 board =
   let

--- a/src/Dovin/Formatting.hs
+++ b/src/Dovin/Formatting.hs
@@ -58,9 +58,18 @@ cardFormatter title matcher board =
 formatCards = intercalate "\n" . map (("      " <>) . formatCard)
 
 formatCard c =
-  let targets = view cardTargets c in
-  "  " <> view cardName c <>
-  " (" <> (intercalate "," . sort . S.toList $ view cardAttributes c) <> ")"
+  let
+    colors = view cardColors c
+    targets = view cardTargets c
+    protection = view cardProtection c
+  in
+  "  " <> view cardName c
+  <> formatColors colors
+  <> " ("
+  <> (intercalate "," . sort $ (
+       formatProtection protection <> S.toList (view cardAttributes c)
+     ))
+  <> ")"
   <> if hasAttribute "creature" c then
        " ("
          <> show (view cardPower c)
@@ -96,6 +105,20 @@ formatCard c =
   where
     formatTarget (TargetCard cn) = cn
     formatTarget (TargetPlayer p) = show p
+
+    formatColorSet = intercalate "" . sort . map show . S.toList
+
+    formatProtection protection =
+      if S.null protection then
+        []
+      else
+        ["protection " <> formatColorSet protection]
+
+    formatColors colors =
+      if S.null colors then
+        ""
+      else
+        " [" <> (intercalate "" . sort . map show . S.toList $ colors) <> "]"
 
 boardFormatter :: Formatter
 boardFormatter board =

--- a/src/Dovin/Formatting.hs
+++ b/src/Dovin/Formatting.hs
@@ -8,6 +8,7 @@ import Dovin.Prelude
 import Dovin.Types
 
 import Control.Monad.Writer (Writer, execWriter, tell)
+import Control.Lens (alongside)
 
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
@@ -110,6 +111,26 @@ boardFormatter board =
     cs = let Right value = execMonad board allCards in value
     formatLocation (Active, Stack) = stackFormatter
     formatLocation l = cardFormatter (show l) (matchLocation l)
+
+dup x = (x, x)
+
+boardFormatter2 :: Formatter
+boardFormatter2 board =
+  let
+    allLocations = nub . sort . map (view (alongside cardController cardZone) . dup) $ cs
+  in
+
+  let formatters = map
+                     formatLocation
+                     allLocations in
+
+  mconcat formatters board
+
+  where
+    cs = let Right value = execMonad board allCards in value
+    formatLocation (Active, Stack) = stackFormatter
+    formatLocation (controller, zone) = cardFormatter (show (controller, zone))
+      (matchController controller <> matchZone zone)
 
 attribute :: Show a => String -> GameMonad a -> FormatMonad ()
 attribute label m = tell [(label, show <$> m)]

--- a/src/Dovin/Formatting.hs
+++ b/src/Dovin/Formatting.hs
@@ -57,6 +57,7 @@ cardFormatter title matcher board =
 formatCards = intercalate "\n" . map (("      " <>) . formatCard)
 
 formatCard c =
+  let targets = view cardTargets c in
   "  " <> view cardName c <>
   " (" <> (intercalate "," . sort . S.toList $ view cardAttributes c) <> ")"
   <> if hasAttribute "creature" c then
@@ -85,6 +86,15 @@ formatCard c =
          <> ")"
      else
       ""
+  <> if length targets > 0 then
+       " (targets: "
+       <> (intercalate "," . sort . map formatTarget $ targets)
+       <> ")"
+     else
+       ""
+  where
+    formatTarget (TargetCard cn) = cn
+    formatTarget (TargetPlayer p) = show p
 
 boardFormatter :: Formatter
 boardFormatter board =

--- a/src/Dovin/Formatting.hs
+++ b/src/Dovin/Formatting.hs
@@ -122,28 +122,14 @@ formatCard c =
 
 boardFormatter :: Formatter
 boardFormatter board =
-  let allLocations = nub . sort . map (view location) $ cs in
-
-  let formatters = map
-                     formatLocation
-                     allLocations in
-
-  mconcat formatters board
-
-  where
-    cs = let Right value = execMonad board allCards in value
-    formatLocation (Active, Stack) = stackFormatter
-    formatLocation l = cardFormatter (show l) (matchLocation l)
-
-boardFormatter2 :: Formatter
-boardFormatter2 board =
   let
-    allLocations = nub . sort . map (view (alongside cardController cardZone) . dup) $ cs
-  in
+    allLocations =
+      nub . sort . map (view (alongside cardController cardZone) . dup) $ cs
 
-  let formatters = map
-                     formatLocation
-                     allLocations in
+    formatters = map
+                   formatLocation
+                   allLocations
+  in
 
   mconcat formatters board
 

--- a/src/Dovin/Helpers.hs
+++ b/src/Dovin/Helpers.hs
@@ -11,7 +11,6 @@ import Data.List (sort)
 import qualified Data.HashMap.Strict as M
 import qualified Data.Set as S
 import Control.Lens (ASetter, _Just)
-import Control.Monad.Reader (ask)
 
 import Text.Parsec
 

--- a/src/Dovin/Matchers.hs
+++ b/src/Dovin/Matchers.hs
@@ -55,10 +55,20 @@ matchOther attribute card =
 matchController player = CardMatcher ("has controller " <> show player) $
   (==) player . view (location . _1)
 
+matchOwner player = CardMatcher ("has owner " <> show player) $
+  (==) player . view cardOwner
+
 matchLesserPower n = CardMatcher ("power < " <> show n) $
   (< n) . view cardPower
 
+matchProtection :: Color -> CardMatcher
+matchProtection color = CardMatcher ("protection from " <> show color) $
+  (S.member color) . view cardProtection
+
 matchNone = CardMatcher "never match" (const False)
+
+matchAll :: CardMatcher
+matchAll = labelMatch "match all" mempty
 
 matchCard :: Card -> CardMatcher
 matchCard = matchName . view cardName

--- a/src/Dovin/Matchers.hs
+++ b/src/Dovin/Matchers.hs
@@ -30,9 +30,10 @@ matchMinusOneCounters n = CardMatcher (show n <> " -1/-1 counters") $
 matchZone :: Zone -> CardMatcher
 matchZone loc = CardMatcher ("in zone " <> show loc) $
   (==) loc . view cardZone
+
 matchLocation :: CardLocation -> CardMatcher
 matchLocation loc = CardMatcher ("in location " <> show loc) $
-  (==) loc . view cardLocation
+  (==) loc . view (alongside cardController cardZone) . dup
 
 matchInPlay = CardMatcher "in play" $ \c -> view cardZone c == Play
 
@@ -51,7 +52,8 @@ matchOtherCreatures = matchOther creature
 
 matchOther :: CardAttribute -> Card -> CardMatcher
 matchOther attribute card =
-     matchLocation (view cardLocation card)
+     matchZone (view cardZone card)
+  <> matchController (view cardController card)
   <> matchAttribute attribute
   <> invert (matchName (view cardName card))
 

--- a/src/Dovin/Matchers.hs
+++ b/src/Dovin/Matchers.hs
@@ -27,11 +27,14 @@ matchMinusOneCounters :: Int -> CardMatcher
 matchMinusOneCounters n = CardMatcher (show n <> " -1/-1 counters") $
   (==) n . view cardMinusOneCounters
 
+matchZone :: Zone -> CardMatcher
+matchZone loc = CardMatcher ("in zone " <> show loc) $
+  (==) loc . view cardZone
 matchLocation :: CardLocation -> CardMatcher
 matchLocation loc = CardMatcher ("in location " <> show loc) $
   (==) loc . view cardLocation
 
-matchInPlay = CardMatcher "in play" $ \c -> snd (view location c) == Play
+matchInPlay = CardMatcher "in play" $ \c -> view cardZone c == Play
 
 matchAttribute :: CardAttribute -> CardMatcher
 matchAttribute attr = CardMatcher ("has attribute " <> attr) $
@@ -53,7 +56,7 @@ matchOther attribute card =
   <> invert (matchName (view cardName card))
 
 matchController player = CardMatcher ("has controller " <> show player) $
-  (==) player . view (location . _1)
+  (==) player . view cardController
 
 matchOwner player = CardMatcher ("has owner " <> show player) $
   (==) player . view cardOwner

--- a/src/Dovin/Matchers.hs
+++ b/src/Dovin/Matchers.hs
@@ -59,9 +59,6 @@ matchOther attribute card =
 matchController player = CardMatcher ("has controller " <> show player) $
   (==) player . view cardController
 
-matchOwner player = CardMatcher ("has owner " <> show player) $
-  (==) player . view cardOwner
-
 matchLesserPower n = CardMatcher ("power < " <> show n) $
   (< n) . view cardPower
 

--- a/src/Dovin/Matchers.hs
+++ b/src/Dovin/Matchers.hs
@@ -88,9 +88,9 @@ matchStrength :: (Int, Int) -> CardMatcher
 matchStrength (p, t) = labelMatch ("P/T = " <> show p <> "/" <> show t) $
   matchPower p <> matchToughness t
 
-matchTarget :: Target -> CardMatcher
+matchTarget :: CardName -> CardMatcher
 matchTarget t = labelMatch ("target = " <> show t) $ CardMatcher ""
-  ((==) t . TargetCard . view cardName)
+  (elem (TargetCard t) . view cardTargets)
 
 missingAttribute = invert . matchAttribute
 

--- a/src/Dovin/Matchers.hs
+++ b/src/Dovin/Matchers.hs
@@ -67,7 +67,7 @@ matchLesserPower n = CardMatcher ("power < " <> show n) $
 
 matchProtection :: Color -> CardMatcher
 matchProtection color = CardMatcher ("protection from " <> show color) $
-  (S.member color) . view cardProtection
+  S.member color . view cardProtection
 
 matchNone = CardMatcher "never match" (const False)
 

--- a/src/Dovin/Prelude.hs
+++ b/src/Dovin/Prelude.hs
@@ -7,7 +7,7 @@ module Dovin.Prelude
   )
   where
 
-import Control.Lens (assign, at, modifying, non, over, set, use, view)
+import Control.Lens (assign, at, modifying, non, over, set, use, view, alongside)
 import Control.Monad (foldM, forM_, unless, when)
 import Control.Monad.Except (catchError, throwError)
 

--- a/src/Dovin/Prelude.hs
+++ b/src/Dovin/Prelude.hs
@@ -3,9 +3,13 @@ module Dovin.Prelude
   ( module Control.Lens
   , module Control.Monad
   , module Control.Monad.Except
+  , dup
   )
   where
 
 import Control.Lens (assign, at, modifying, non, over, set, use, view)
 import Control.Monad (foldM, forM_, unless, when)
 import Control.Monad.Except (catchError, throwError)
+
+dup :: a -> (a, a)
+dup x = (x, x)

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -15,8 +15,15 @@ import qualified Data.Set as S
 import GHC.Generics
 
 data Color = Red | Green | Blue | Black | White
-  deriving (Show, Eq, Ord, Enum, Bounded)
+  deriving (Eq, Ord, Enum, Bounded)
 type Colors = S.Set Color
+
+instance Show Color where
+  show Red = "R"
+  show Green = "G"
+  show Blue = "U"
+  show Black = "B"
+  show White = "W"
 
 allColors :: Colors
 allColors = S.fromList [minBound..maxBound]

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -31,6 +31,7 @@ type ManaString = String
 data Location = Hand | Graveyard | Play | Stack | Exile | Deck | Command
   deriving (Show, Eq, Ord)
 
+type Zone = Location
 -- The original CardEffect type. This is deprecated as of V3, replaced by
 -- LayeredEffect.
 data CardEffect = CardEffect
@@ -147,6 +148,8 @@ data Card = Card
   { _cardName :: CardName
   , _location :: (Player, Location)
   , _cardOwner :: Player
+  , _cardController :: Player
+  , _cardZone :: Zone
   , _cardDefaultAttributes :: CardAttributes
   , _cardAttributes :: CardAttributes
   , _cardStrength :: CardStrength
@@ -265,9 +268,6 @@ cardToughness f parent = fmap
     setToughness t (CardStrength p _) = CardStrength p t
     toughness (CardStrength _ t) = t
 
-cardController :: Control.Lens.Lens' Card Player
-cardController = cardLocation . _1
-
 manaPoolFor p = manaPool . at p . non mempty
 
 -- I can't figure out the right type signature for manaPoolFor, so instead
@@ -325,6 +325,8 @@ mkCard name location =
     , _cardAbilityEffects = mempty
     , _cardTimestamp = 0
     , _cardOwner = fst location
+    , _cardController = fst location
+    , _cardZone = Play
     , _cardProtection = mempty
     }
 

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -19,12 +19,12 @@ type Colors = S.Set Color
 
 type CardName = String
 type CardAttribute = String
-data Player = Active | Opponent deriving (Show, Eq, Generic, Ord)
+data Player = Active | Opponent | OpponentN Integer deriving (Show, Eq, Generic, Ord)
 -- This is pretty dodgy - one char per mana - but works for now.
 type ManaPool = String
 type ManaString = String
 -- TODO: Stack shouldn't be in here because there is only one of them
-data Location = Hand | Graveyard | Play | Stack | Exile | Deck
+data Location = Hand | Graveyard | Play | Stack | Exile | Deck | Command
   deriving (Show, Eq, Ord)
 
 -- The original CardEffect type. This is deprecated as of V3, replaced by
@@ -88,7 +88,7 @@ mkEffect enabled filter action = CardEffect
   -- For an effect to be enabled, it's host card must currently match this
   -- matcher.
   { _effectEnabled = enabled
-  -- If the effect is enabled, this filter determines wheter any particular
+  -- If the effect is enabled, this filter determines whether any particular
   -- card is affected by it.
   , _effectFilter = filter
   -- The action to apply to affected cards.
@@ -291,6 +291,10 @@ emptyEnv = Env
   { _envTemplate = emptyCard
   , _envSBAEnabled = True
   , _envActor = Active
+  -- This is a bit of a hack for allowing us to default the owner to the
+  -- location if none was specified. Ideally, the type of cardOwner in the
+  -- template would be a Maybe, but that would require duplicating the Card
+  -- type which doesn't seem worth it.
   , _envOwner = Nothing
   }
 
@@ -300,7 +304,6 @@ mkCard name location =
   Card
     { _cardName = name
     , _location = location
-    , _cardOwner = fst location
     , _cardDefaultAttributes = mempty
     , _cardColors = mempty
     , _cardAttributes = mempty
@@ -316,6 +319,7 @@ mkCard name location =
     , _cardPassiveEffects = mempty
     , _cardAbilityEffects = mempty
     , _cardTimestamp = 0
+    , _cardOwner = fst location
     }
 
 opposing :: Player -> Player

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -3,7 +3,9 @@
 
 module Dovin.Types where
 
-import Control.Lens (Lens', makeLenses, over, view, _1, _2, at, non)
+import Dovin.Prelude (dup)
+
+import Control.Lens (Lens', makeLenses, over, view, _1, _2, at, non, alongside, set)
 import Control.Monad.Reader (ReaderT, Reader)
 import Control.Monad.Identity (runIdentity, Identity)
 import Control.Monad.Except (ExceptT)
@@ -153,7 +155,6 @@ data AbilityEffect = AbilityEffect Timestamp EffectDuration [LayeredEffectPart]
 
 data Card = Card
   { _cardName :: CardName
-  , _location :: (Player, Location)
   , _cardController :: Player
   , _cardZone :: Zone
   , _cardDefaultAttributes :: CardAttributes
@@ -253,7 +254,9 @@ mkStep id label state = Step
   }
 
 cardLocation :: Control.Lens.Lens' Card (Player, Location)
-cardLocation = location
+cardLocation f parent = fmap
+  (\(controller, zone) -> (set cardController controller . set cardZone zone) parent)
+  (f . view (alongside cardController cardZone) . dup $ parent)
 
 -- TODO: How to define these lenses using built-in Lens primitives
 -- (Control.Lens.Wrapped?)
@@ -308,7 +311,6 @@ emptyCard = mkCard "" (Active, Hand)
 mkCard name location =
   Card
     { _cardName = name
-    , _location = location
     , _cardDefaultAttributes = mempty
     , _cardColors = mempty
     , _cardAttributes = mempty

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -14,8 +14,12 @@ import Data.Hashable (Hashable)
 import qualified Data.Set as S
 import GHC.Generics
 
-data Color = Red | Green | Blue | Black | White deriving (Show, Eq, Ord)
+data Color = Red | Green | Blue | Black | White
+  deriving (Show, Eq, Ord, Enum, Bounded)
 type Colors = S.Set Color
+
+allColors :: Colors
+allColors = S.fromList [minBound..maxBound]
 
 type CardName = String
 type CardAttribute = String
@@ -152,6 +156,7 @@ data Card = Card
   , _cardEffects :: [CardEffect]
   , _cardCmc :: Int
   , _cardColors :: Colors
+  , _cardProtection :: Colors
   , _cardTargets :: [Target]
 
   , _cardTimestamp :: Timestamp
@@ -320,6 +325,7 @@ mkCard name location =
     , _cardAbilityEffects = mempty
     , _cardTimestamp = 0
     , _cardOwner = fst location
+    , _cardProtection = mempty
     }
 
 opposing :: Player -> Player

--- a/src/Dovin/Types.hs
+++ b/src/Dovin/Types.hs
@@ -154,7 +154,6 @@ data AbilityEffect = AbilityEffect Timestamp EffectDuration [LayeredEffectPart]
 data Card = Card
   { _cardName :: CardName
   , _location :: (Player, Location)
-  , _cardOwner :: Player
   , _cardController :: Player
   , _cardZone :: Zone
   , _cardDefaultAttributes :: CardAttributes
@@ -218,7 +217,6 @@ data Env = Env
   { _envTemplate :: Card
   , _envSBAEnabled :: Bool
   , _envActor :: Player
-  , _envOwner :: Maybe Player
   }
 
 type StepIdentifier = (Maybe String, Int)
@@ -303,11 +301,6 @@ emptyEnv = Env
   { _envTemplate = emptyCard
   , _envSBAEnabled = True
   , _envActor = Active
-  -- This is a bit of a hack for allowing us to default the owner to the
-  -- location if none was specified. Ideally, the type of cardOwner in the
-  -- template would be a Maybe, but that would require duplicating the Card
-  -- type which doesn't seem worth it.
-  , _envOwner = Nothing
   }
 
 mkStrength (p, t) = CardStrength p t
@@ -331,7 +324,6 @@ mkCard name location =
     , _cardPassiveEffects = mempty
     , _cardAbilityEffects = mempty
     , _cardTimestamp = 0
-    , _cardOwner = fst location
     , _cardController = fst location
     , _cardZone = Play
     , _cardProtection = mempty

--- a/src/Dovin/V1.hs
+++ b/src/Dovin/V1.hs
@@ -55,7 +55,11 @@ validateLife = flip Dovin.Actions.validateLife
 
 -- | Set the location of the created card.
 withLocation :: CardLocation -> GameMonad () -> GameMonad ()
-withLocation loc = local (set (envTemplate . cardLocation) loc)
+withLocation (p, loc) = local (
+      set (envTemplate . cardLocation) (p, loc)
+    . set (envTemplate . cardController) p
+    . set (envTemplate . cardZone) loc
+  )
 
 activate mana targetName = do
   card <- requireCard targetName mempty

--- a/src/Dovin/V1.hs
+++ b/src/Dovin/V1.hs
@@ -14,6 +14,8 @@ module Dovin.V1
   , trigger
   , fork
   , withEffect
+  , castFromLocation
+  , targetInLocation
   ) where
 
 import Dovin.Runner
@@ -104,3 +106,10 @@ withEffect applyCondition matcher action = do
   let name = "legacy V2 effect"
 
   withEffectWhen applyConditionV3 matcherV3 actionV3 name
+
+castFromLocation :: CardLocation -> ManaPool -> CardName -> GameMonad ()
+castFromLocation (player, zone) mana =
+  as player . castFromZone zone mana
+
+targetInLocation :: CardLocation -> CardName -> GameMonad ()
+targetInLocation loc cn = validate cn (matchLocation loc)

--- a/src/Dovin/V2.hs
+++ b/src/Dovin/V2.hs
@@ -19,14 +19,14 @@ module Dovin.V2
   , module Dovin.Helpers
   , module Dovin.Types
   , module Dovin.Matchers
-  , view
-  , withEffect
+  , module Dovin.V1
+  , module Control.Lens
   )
   where
 
 import Dovin.Runner
 import Dovin.Actions
-import Dovin.V1 (withEffect)
+import Dovin.V1 (withEffect, targetInLocation)
 import Dovin.Attributes
 import Dovin.Builder hiding (withEffect)
 import Dovin.Formatting

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -31,6 +31,7 @@ import Dovin.Effects
   , effectAddAbility
   , effectNoAbilities
   , effectAddType
+  , effectProtectionF
   , enabledInPlay
   , viewSelf
   , askSelf

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -32,6 +32,7 @@ import Dovin.Effects
   , effectNoAbilities
   , effectAddType
   , effectProtectionF
+  , effectControlF
   , enabledInPlay
   , viewSelf
   , askSelf

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -24,22 +24,7 @@ module Dovin.V3
 
 import Dovin.V2 hiding (withEffect, cardStrengthModifier)
 import Dovin.Builder (withEffect)
-import Dovin.Effects
-  ( effectPTSet
-  , effectPTSetF
-  , effectPTAdjust
-  , effectPTAdjustF
-  , effectAddAbility
-  , effectNoAbilities
-  , effectAddType
-  , effectProtectionF
-  , effectControl
-  , effectControlF
-  , enabledInPlay
-  , viewSelf
-  , askSelf
-  , askCards
-  )
+import Dovin.Effects hiding (resolveEffects)
 
 -- | Now a no-op, removed in subsequent versions. Was unused.
 withOwner :: Player -> GameMonad () -> GameMonad ()

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -18,6 +18,7 @@ module Dovin.V3
   ( module Dovin.V2
   , module Dovin.Builder
   , module Dovin.Effects
+  , withOwner
   )
   where
 
@@ -40,3 +41,6 @@ import Dovin.Effects
   , askCards
   )
 
+-- | Now a no-op, removed in subsequent versions. Was unused.
+withOwner :: Player -> GameMonad () -> GameMonad ()
+withOwner = return . const (return ())

--- a/src/Dovin/V3.hs
+++ b/src/Dovin/V3.hs
@@ -32,6 +32,7 @@ import Dovin.Effects
   , effectNoAbilities
   , effectAddType
   , effectProtectionF
+  , effectControl
   , effectControlF
   , enabledInPlay
   , viewSelf

--- a/src/Dovin/V4.hs
+++ b/src/Dovin/V4.hs
@@ -20,6 +20,9 @@ V4 adds a lot of new flexibility while better aligning with the official rules:
 * Remove 'move'. Use one of the higher level functions instead (such as
   'moveTo')
 * 'addArtifact' was no longer adds the 'enchantment' attribute to cards.
+* 'OpponentN Int' constructor for 'Player' allows for multiplayer scenarios.
+* 'combatDamageTo' to send damage to a different player than the default
+  'Opponent'.
 -}
 module Dovin.V4
   ( module Dovin.V3

--- a/src/Dovin/V4.hs
+++ b/src/Dovin/V4.hs
@@ -1,0 +1,36 @@
+{-|
+V4 adds a lot of new flexibility while better aligning with the official rules:
+
+* Adds 'Zone' type as a better name for previous 'Location' type.
+* Adds 'withZone' builder, replacing 'withLocation'.
+* Adds 'matchZone' and 'matchController' matchers.
+* Adds 'cardController' and 'cardZone' lens, replacing 'cardLocation'.
+* Adds 'cardTargets' lens and 'withCardTarget'. Cards can now store zero of
+  more targets, which can be referenced in effects and validations.
+* Adds 'effectControl' and 'effectControlF', a layer 2 effect to change the
+  controller of a card.
+* Cards can have colors via 'withColors' and 'cardColors'.
+* Cards can have protection from colors with 'effectProtection' and
+  'effectProtectionF' (layer 6). This is not respected by any built-in effects
+  currently, but can be used in your own effects and validations.
+* Add 'check' as a non-terminal version of 'validate' that returns a boolean
+  rather than throwing an error. This can be used to write dynamic solutions
+  based on the state of the board.
+* Remove 'CardLocation' type.
+* Remove 'move'. Use one of the higher level functions instead (such as
+  'moveTo')
+* 'addArtifact' was no longer adds the 'enchantment' attribute to cards.
+-}
+module Dovin.V4
+  ( module Dovin.V3
+  )
+  where
+
+import Dovin.V3 hiding
+  ( withLocation
+  , cardLocation
+  , move
+  , CardLocation
+  , Location
+  , withOwner
+  )

--- a/src/Solutions.hs
+++ b/src/Solutions.hs
@@ -3,6 +3,7 @@ import Control.Lens (view)
 import Dovin.Types (stepNumber)
 
 import qualified Solutions.ChannelFireball
+import qualified Solutions.CommanderLegends
 import qualified Solutions.Core19_9
 import qualified Solutions.Dominaria5
 import qualified Solutions.Example
@@ -23,6 +24,7 @@ import qualified Solutions.WarOfTheSpark2
 
 all = [
   ("ChannelFireball", Solutions.ChannelFireball.solution, Solutions.ChannelFireball.formatter),
+  ("CommanderLegends", Solutions.CommanderLegends.solution, Solutions.CommanderLegends.formatter),
   ("Core19_9", Solutions.Core19_9.solution, Solutions.Core19_9.formatter . view stepNumber),
   ("Dominaria5", Solutions.Dominaria5.solution, Solutions.Dominaria5.formatter . view stepNumber),
   ("Example", Solutions.Example.solution, Solutions.Example.formatter),

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -4,14 +4,10 @@ import Dovin.V3
 import Data.Maybe (mapMaybe)
 
 import Control.Monad (forM_, foldM, when)
-import Control.Monad.Except (catchError, throwError)
+import Control.Monad.Except (catchError)
 import Control.Lens (modifying, at, non, use, assign, Lens')
 
 import qualified Data.Set as S
-import qualified Data.HashMap.Strict as M
-
-commander = "commander"
-pirate = "pirate"
 
 solution :: GameMonad ()
 solution = do
@@ -51,7 +47,7 @@ solution = do
               let colors =
                     foldl S.union mempty (map (view cardColors) commanders)
 
-              return (S.difference allColors colors)
+              return $ S.difference allColors colors
           )
           ]
           "Attached gets +3/+3 and pro colors NOT in commander colors"
@@ -361,6 +357,9 @@ malcolmCounter :: Control.Lens.Lens' Board Int
 malcolmCounter = counters . at "malcolm" . non 0
 
 allPlayers = [Active, OpponentN 1, OpponentN 2, OpponentN 3]
+
+commander = "commander"
+pirate = "pirate"
 
 attributes = attributeFormatter $ do
   attribute "life #1" $ countLife (OpponentN 1)

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -1,0 +1,94 @@
+module Solutions.CommanderLegends where
+
+import Dovin.V2
+import Dovin.Prelude
+
+import Data.Maybe (mapMaybe)
+
+solution :: GameMonad ()
+solution = do
+  step "Initial state" $ do
+    as (OpponentN 1) $ setLife 29
+    as (OpponentN 2) $ setLife 23
+    as (OpponentN 3) $ setLife 46
+
+    as (OpponentN 3) $ do
+      withLocation Play $
+        addCreature (4, 4) "Sengir, the Dark Baron"
+
+    as Active $ do
+      withLocation Hand $ do
+        addCreature (2, 2) "Malcolm, Keen-Eyed Navigator"
+        addInstant "Soul's Fire"
+
+      withLocation Play $ do
+        addLands 2 "Island"
+        addLands 2 "Mountain"
+        addLands 2 "Plains"
+
+        addCreature (4, 4) "Port Razer"
+        addCreature (2, 2) "Ardenn, Intrepid Archaeologist"
+
+        withOwner (OpponentN 3)
+          -- $ withTarget (TargetCard "Test")
+          $ withEffect
+              matchInPlay
+              -- TODO: Tidy all this up
+              (foldr
+                (\cn m -> matchName cn `matchOr` m)
+                (matchName "")
+                . mapMaybe extractCardTarget . view cardTargets)
+              (pure . over cardStrengthModifier (mkStrength (3, 3) <>))
+              $ addArtifact "Commander's Plate"
+        withTarget (TargetCard "Commander's Plate") $ addAura "Confiscate"
+        withTarget (TargetCard "Ardenn, Intrepid Archaeologist")
+          $ withEffect
+              matchInPlay
+              -- TODO: Tidy all this up
+              (foldr
+                (\cn m -> matchName cn `matchOr` m)
+                (matchName "")
+                . mapMaybe extractCardTarget . view cardTargets)
+              (pure . over cardStrengthModifier (mkStrength (2, 2) <>))
+              $ addArtifact "Seraphic Greatsword"
+
+
+  step "Cast Malcolm" $ do
+    tapForMana "U" "Island 1"
+    tapForMana "W" "Plains 1"
+    tapForMana "W" "Plains 2"
+
+    cast "2U" "Malcolm, Keen-Eyed Navigator" >> resolveTop
+
+  step "Soul's Fire to kill Baron" $ do
+    tapForMana "R" "Mountain 1"
+    tapForMana "R" "Mountain 2"
+    tapForMana "U" "Island 2"
+
+    cast "2R" "Soul's Fire" >> resolveTop
+
+    target "Port Razer"
+    damage (view cardPower) (TargetCard "Sengir, the Dark Baron") "Port Razer"
+
+  step "First Combat, move Plate & Greatsword to Port Razer" $ do
+    transitionTo BeginCombat
+
+    trigger "Ardenn Attach" "Ardenn, Intrepid Archaeologist" >> resolveTop
+
+    attach "Commander's Plate" "Port Razer"
+    attach "Seraphic Greatsword" "Port Razer"
+
+attach cn tn = do
+  c <- requireCard cn $ matchInPlay
+
+  modifyCard cardTargets (const [TargetCard tn]) cn
+
+extractCardTarget (TargetCard cn) = Just cn
+extractCardTarget _ = Nothing
+
+attributes = attributeFormatter $ do
+  attribute "life #1" $ countLife (OpponentN 1)
+  attribute "life #2" $ countLife (OpponentN 2)
+  attribute "life #3" $ countLife (OpponentN 3)
+
+formatter _ = attributes <> boardFormatter

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -375,7 +375,7 @@ attackFormatter = cardFormatter "attackers"
 playFormatters = foldr (<>) mempty . map playFormatter
 
 formatter step = case view stepNumber step of
-  1 -> attributes <> boardFormatter2
+  1 -> attributes <> boardFormatter
   3 -> playFormatters [Active, OpponentN 3]
   5 -> attributes <> attackFormatter <> playFormatter (OpponentN 3)
   8 -> attributes

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -9,6 +9,8 @@ import Control.Lens (modifying, at, non, use, assign, Lens')
 
 import qualified Data.Set as S
 
+-- Note this solution does not account for the monarch effect present in the
+-- problem.
 solution :: GameMonad ()
 solution = do
   step "Initial state" $ do

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -1,5 +1,4 @@
-module Solutions.CommanderLegends where
-
+module Solutions.CommanderLegends where 
 import Dovin.V3
 
 import Data.Maybe (mapMaybe)
@@ -21,27 +20,27 @@ solution = do
     as (OpponentN 3) $ setLife 46
 
     as (OpponentN 2) $ do
-      withLocation Play $
+      withZone Play $
         addCreature (5, 4) "Frenzied Saddlebrute"
 
     as (OpponentN 3) $ do
-      withLocation Play $ do
+      withZone Play $ do
         addCreature (4, 4) "Sengir, the Dark Baron"
         withColors [Black, Green, Blue]
           $ withAttribute commander
           $ addCreature (2, 4) "Archelos, Lagoon Mystic"
 
     as Active $ do
-      withLocation Hand $ do
+      withZone Hand $ do
         withAttribute flying $ addCreature (2, 2) "Malcolm, Keen-Eyed Navigator"
         addInstant "Soul's Fire"
 
-      withLocation Command $ do
+      withZone Command $ do
         withAttribute commander
           $ withColors [Red, Blue]
           $ addCreature (4, 4) "Kraum, Ludevic's Opus"
 
-      withLocation Play $ do
+      withZone Play $ do
         addLands 2 "Island"
         addLands 2 "Mountain"
         addLands 2 "Plains"
@@ -51,14 +50,14 @@ solution = do
           $ withColors [White]
           $ addCreature (2, 2) "Ardenn, Intrepid Archaeologist"
 
-        withOwner (OpponentN 3)
+        as (OpponentN 3)
           $ withEffect
               -- TODO: Tidy all this up
               ((foldr (\cn m -> matchName cn `matchOr` m) matchNone
                 . mapMaybe extractCardTarget) <$> viewSelf cardTargets)
               [ effectPTAdjust (3, 3)
               , effectProtectionF (const $ do
-                  controller <- viewSelf cardOwner
+                  controller <- viewSelf cardController
                   commanders <- askCards
                     (matchController controller <> matchAttribute commander)
 
@@ -71,12 +70,12 @@ solution = do
               "Equipped gets +3/+3 and pro colors NOT in commander colors"
               $ addArtifact "Commander's Plate"
         withCardTarget "Commander's Plate"
-          $ withEffect
-              ((foldr (\cn m -> matchName cn `matchOr` m) matchNone
-                . mapMaybe extractCardTarget) <$> viewSelf cardTargets)
-              [ effectSetControllerF (const $ viewSelf cardOwner)
-              ]
-              "Gain control of target"
+           $ withEffect
+               ((foldr (\cn m -> matchName cn `matchOr` m) matchNone
+                 . mapMaybe extractCardTarget) <$> viewSelf cardTargets)
+               [ effectControlF (const $ viewSelf cardController)
+               ]
+               "Gain control of target"
           $ addAura "Confiscate"
         withCardTarget "Ardenn, Intrepid Archaeologist"
           $ withEffect
@@ -161,7 +160,7 @@ attributes = attributeFormatter $ do
   attribute "life #2" $ countLife (OpponentN 2)
   attribute "life #3" $ countLife (OpponentN 3)
 
-formatter _ = attributes <> boardFormatter
+formatter _ = attributes <> boardFormatter2
 
 matchCanBlock =
   matchInPlay <> matchAttribute creature <> missingAttribute tapped

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -21,19 +21,19 @@ solution = do
     as (OpponentN 2) $ setLife 23
     as (OpponentN 3) $ setLife 46
 
-    as (OpponentN 1) $ do
+    as (OpponentN 1) $
       withZone Play $
         withAttribute flying
         $ addCreature (5, 5) "Archon of Coronation"
 
-    as (OpponentN 2) $ do
+    as (OpponentN 2) $
       withZone Play $ do
         withColors [Red]
           $ addCreature (5, 4) "Frenzied Saddlebrute"
         withColors [Red, White]
           $ addCreature (7, 5) "Dargo, the Shipwrecker"
 
-    as (OpponentN 3) $ do
+    as (OpponentN 3) $
       withZone Play $ do
         addCreature (4, 4) "Sengir, the Dark Baron"
         withColors [Black, Green, Blue]
@@ -64,8 +64,8 @@ solution = do
         addInstant "Soul's Fire"
         addInstant "Wrong Turn"
 
-      withZone Command $ do
-        withAttribute commander
+      withZone Command
+        $ withAttribute commander
           $ withColors [Red, Blue]
           $ addCreature (4, 4) "Kraum, Ludevic's Opus"
 
@@ -162,8 +162,7 @@ solution = do
     trigger "Another combat phase" "Port Razer"
     trigger "Treasures" "Malcolm, Keen-Eyed Navigator"
 
-  step "Create treasures from Malcomn's trigger" $ do
-    resolveMalcolmTrigger
+  step "Create treasures from Malcomn's trigger" resolveMalcolmTrigger
 
   step "Cast Wrong Turn to give Archon back to P1" $ do
     tapForMana "U" "Treasure 1"
@@ -179,14 +178,8 @@ solution = do
     addEffect (effectControl (OpponentN 1)) "Archon of Coronation"
     gainAttribute summoned "Archon of Coronation"
 
-  step "Untap and another combat phase from Port Razer's trigger" $ do
-    resolve "Another combat phase"
-
-    forCards (matchInPlay <> matchController Active) $ \cn -> do
-      loseAttribute attacking cn
-      loseAttribute tapped cn
-
-    transitionToForced BeginCombat
+  step "Untap and another combat phase from Port Razer's trigger"
+    resolvePortRazerTrigger
 
   step "Third combat, move Confiscate & Greatsword to Saddlebrute" $ do
     trigger "Ardenn Attach" "Ardenn, Intrepid Archaeologist" >> resolveTop
@@ -212,16 +205,10 @@ solution = do
     trigger "Another combat phase" "Port Razer"
     trigger "Treasures" "Malcolm, Keen-Eyed Navigator"
 
-  step "Create treasures from Malcomn's trigger (unused)" $ do
-    resolveMalcolmTrigger
+  step "Create treasures from Malcomn's trigger (unused)" resolveMalcolmTrigger
 
-  step "Untap and another combat phase from Port Razer's trigger" $ do
-    resolve "Another combat phase"
-    forCards (matchInPlay <> matchController Active) $ \cn -> do
-      loseAttribute attacking cn
-      loseAttribute tapped cn
-
-    transitionToForced BeginCombat
+  step "Untap and another combat phase from Port Razer's trigger"
+    resolvePortRazerTrigger
 
   step "Fourth combat, move Greatsword to Angel" $ do
     trigger "Ardenn Attach" "Ardenn, Intrepid Archaeologist" >> resolveTop
@@ -243,6 +230,14 @@ solution = do
       [ "Angel 3"
       ]
 
+resolvePortRazerTrigger = do
+  resolve "Another combat phase"
+  forCards (matchInPlay <> matchController Active) $ \cn -> do
+    loseAttribute attacking cn
+    loseAttribute tapped cn
+
+  transitionToForced BeginCombat
+
 resolveMalcolmTrigger = do
   resolve "Treasures"
   n <- use malcolmCounter
@@ -259,7 +254,7 @@ resolveMalcolmTrigger = do
   assign malcolmCounter 0
 
 attach cn tn = do
-  c <- requireCard cn $ matchInPlay
+  c <- requireCard cn matchInPlay
 
   validate matchInPlay tn
 

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -1,9 +1,17 @@
 module Solutions.CommanderLegends where
 
-import Dovin.V2
-import Dovin.Prelude
+import Dovin.V3
 
 import Data.Maybe (mapMaybe)
+
+import Debug.Trace
+
+import Control.Monad (forM_)
+import Control.Monad.Except (catchError)
+
+import qualified Data.Set as S
+
+commander = "commander"
 
 solution :: GameMonad ()
 solution = do
@@ -12,14 +20,25 @@ solution = do
     as (OpponentN 2) $ setLife 23
     as (OpponentN 3) $ setLife 46
 
-    as (OpponentN 3) $ do
+    as (OpponentN 2) $ do
       withLocation Play $
+        addCreature (5, 4) "Frenzied Saddlebrute"
+
+    as (OpponentN 3) $ do
+      withLocation Play $ do
         addCreature (4, 4) "Sengir, the Dark Baron"
+        withColors [Black, Green, Blue] $
+          addCreature (2, 4) "Archelos, Lagoon Mystic"
 
     as Active $ do
       withLocation Hand $ do
-        addCreature (2, 2) "Malcolm, Keen-Eyed Navigator"
+        withAttribute flying $ addCreature (2, 2) "Malcolm, Keen-Eyed Navigator"
         addInstant "Soul's Fire"
+
+      withLocation Command $ do
+        withAttribute commander
+          $ withColors [Red, Blue]
+          $ addCreature (4, 4) "Kraum, Ludevic's Opus"
 
       withLocation Play $ do
         addLands 2 "Island"
@@ -27,29 +46,41 @@ solution = do
         addLands 2 "Plains"
 
         addCreature (4, 4) "Port Razer"
-        addCreature (2, 2) "Ardenn, Intrepid Archaeologist"
+        withAttribute commander
+          $ withColors [White]
+          $ addCreature (2, 2) "Ardenn, Intrepid Archaeologist"
 
         withOwner (OpponentN 3)
-          -- $ withTarget (TargetCard "Test")
           $ withEffect
-              matchInPlay
               -- TODO: Tidy all this up
-              (foldr
-                (\cn m -> matchName cn `matchOr` m)
-                (matchName "")
-                . mapMaybe extractCardTarget . view cardTargets)
-              (pure . over cardStrengthModifier (mkStrength (3, 3) <>))
+              ((foldr (\cn m -> matchName cn `matchOr` m) matchNone
+                . mapMaybe extractCardTarget) <$> viewSelf cardTargets)
+              [ effectPTAdjust (3, 3)
+              , effectProtectionF (const $ do
+                  controller <- viewSelf cardController
+                  commanders <- askCards
+                    (matchController controller <> matchAttribute commander)
+
+                  let colors =
+                        foldl S.union mempty (map (view cardColors) commanders)
+  
+
+                  return (S.difference allColors colors)
+              )
+              ]
+              "Equipped gets +3/+3 and pro colors NOT in commander colors"
               $ addArtifact "Commander's Plate"
-        withTarget (TargetCard "Commander's Plate") $ addAura "Confiscate"
-        withTarget (TargetCard "Ardenn, Intrepid Archaeologist")
+        withCardTarget "Commander's Plate" $ addAura "Confiscate"
+        withCardTarget "Ardenn, Intrepid Archaeologist"
           $ withEffect
-              matchInPlay
               -- TODO: Tidy all this up
-              (foldr
+              ((foldr
                 (\cn m -> matchName cn `matchOr` m)
                 (matchName "")
-                . mapMaybe extractCardTarget . view cardTargets)
-              (pure . over cardStrengthModifier (mkStrength (2, 2) <>))
+                . mapMaybe extractCardTarget) <$> viewSelf cardTargets)
+              [ effectPTAdjust (2, 2)
+              ]
+              "Equipped gets +2/+2"
               $ addArtifact "Seraphic Greatsword"
 
 
@@ -78,6 +109,18 @@ solution = do
     attach "Commander's Plate" "Port Razer"
     attach "Seraphic Greatsword" "Port Razer"
 
+    attackPlayerWith (OpponentN 3) 
+      [ "Port Razer", "Malcolm, Keen-Eyed Navigator" ]
+
+    trigger "Attacking angel" "Seraphic Greatsword" >> resolveTop
+    -- TODO: validate player being attacked has most life
+
+    withAttributes [token, tapped, attacking, flying] $ addCreature (4, 4) "Angel 1"
+
+    forCards (matchAttribute attacking) $ \cn -> do
+      -- TODO Correct colors from blockers
+      validate (matchAttribute flying `matchOr` matchProtection Black) cn
+
 attach cn tn = do
   c <- requireCard cn $ matchInPlay
 
@@ -92,3 +135,31 @@ attributes = attributeFormatter $ do
   attribute "life #3" $ countLife (OpponentN 3)
 
 formatter _ = attributes <> boardFormatter
+
+-- copy of 'attackWith', but allow haste-y attacking if a different player
+-- controls Frenzied Saddlebrute
+attackPlayerWith :: Player -> [CardName] -> GameMonad ()
+attackPlayerWith player cs = do
+  transitionTo DeclareAttackers
+
+  hasteMatcher <-
+    (do
+      validate (matchInPlay <> invert (matchController player)) "Frenzied Saddlebrute"
+      return matchAll
+    ) `catchError` (const . return $ matchAttribute haste)
+
+  forM_ cs $ \cn -> do
+    c <- requireCard cn
+           (matchInPlay
+             <> matchAttribute "creature"
+             <> missingAttribute "defender"
+             <> labelMatch "does not have summoning sickness" (
+                  hasteMatcher
+                  `matchOr`
+                  missingAttribute summoned
+                ))
+    forCards
+      (matchName cn <> missingAttribute vigilance)
+      -- Can't use 'tap' here because it checks summoning sickness.
+      (gainAttribute tapped)
+    gainAttribute attacking cn

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -247,6 +247,145 @@ solution = do
 
     transitionToForced BeginCombat
 
+  step "Third combat, move Confiscate & Greatsword to Saddlebrute" $ do
+    trigger "Ardenn Attach" "Ardenn, Intrepid Archaeologist" >> resolveTop
+
+    attach "Confiscate" "Frenzied Saddlebrute"
+    gainAttribute summoned "Frenzied Saddlebrute"
+    attach "Seraphic Greatsword" "Frenzied Saddlebrute"
+
+  step "Third combat" $ do
+    transitionTo DeclareAttackers
+
+    -- Technically out of order, but simplies things a bit
+    trigger "Attacking angel" "Seraphic Greatsword" >> resolveTop
+    -- TODO: validate player being attacked has most life
+
+    withLocation Play
+      $ withAttributes [token, tapped, attacking, flying]
+      $ addCreature (4, 4) "Angel 3"
+
+    let attackingP1 =
+          [ "Port Razer"
+          , "Frenzied Saddlebrute"
+          , "Ardenn, Intrepid Archaeologist"
+          , "Angel 3"
+          ]
+    let attackingP2 = [ ]
+    let attackingP3 =
+          [ "Angel 1"
+          , "Angel 2"
+          , "Malcolm, Keen-Eyed Navigator"
+          ]
+
+    attackPlayerWith (OpponentN 1) attackingP1
+    attackPlayerWith (OpponentN 2) attackingP2
+    attackPlayerWith (OpponentN 3) attackingP3
+
+    forCards (matchController (OpponentN 1) <> matchCanBlock) $ \blocker -> do
+      blockerColors <- view cardColors <$> requireCard blocker mempty
+
+      forM_ attackingP1 $
+        validate (matchAttribute flying `matchOr` matchProtectionAny blockerColors)
+
+    forCards (matchController (OpponentN 2) <> matchCanBlock) $ \blocker -> do
+      blockerColors <- view cardColors <$> requireCard blocker mempty
+
+      forM_ attackingP2 $
+        validate (matchAttribute flying `matchOr` matchProtectionAny blockerColors)
+
+    forCards (matchController (OpponentN 3) <> matchCanBlock) $ \blocker -> do
+      blockerColors <- view cardColors <$> requireCard blocker mempty
+
+      forM_ attackingP3 $
+        validate (matchAttribute flying `matchOr` matchProtectionAny blockerColors)
+
+    forM_ attackingP1 $ combatDamageTo (TargetPlayer $ OpponentN 1) []
+    forM_ attackingP2 $ combatDamageTo (TargetPlayer $ OpponentN 2) []
+    forM_ attackingP3 $ combatDamageTo (TargetPlayer $ OpponentN 3) []
+
+    trigger "Another combat phase" "Port Razer"
+    trigger "Treasures" "Malcolm, Keen-Eyed Navigator"
+
+    validateLife 7 (OpponentN 1)
+    validateLife 16 (OpponentN 2)
+    validateLife 4 (OpponentN 3)
+
+  step "Resolve combat triggers" $ do
+    -- TODO: Automatically figure out how many there should be, or validate
+    resolve "Treasures"
+    withZone Play $ addArtifact "Treasure 4"
+    withZone Play $ addArtifact "Treasure 5"
+
+    resolve "Another combat phase"
+    forCards (matchInPlay <> matchController Active) $ \cn -> do
+      loseAttribute attacking cn
+      loseAttribute tapped cn
+
+    transitionToForced BeginCombat
+
+  step "Fourth combat, move Greatsword to Angel" $ do
+    trigger "Ardenn Attach" "Ardenn, Intrepid Archaeologist" >> resolveTop
+    attach "Seraphic Greatsword" "Angel 1"
+
+  step "Fourth combat" $ do
+    transitionTo DeclareAttackers
+
+    -- Technically out of order, but simplies things a bit
+    trigger "Attacking angel" "Seraphic Greatsword" >> resolveTop
+    -- TODO: validate player being attacked has most life
+
+    withLocation Play
+      $ withAttributes [token, tapped, attacking, flying]
+      $ addCreature (4, 4) "Angel 4"
+
+    let attackingP1 =
+          [ "Frenzied Saddlebrute"
+          , "Ardenn, Intrepid Archaeologist"
+          ]
+    let attackingP2 =
+          [ "Angel 1"
+          , "Angel 2"
+          , "Angel 4"
+          , "Malcolm, Keen-Eyed Navigator"
+          ]
+    let attackingP3 =
+          [ "Angel 3"
+          ]
+
+    attackPlayerWith (OpponentN 1) attackingP1
+    attackPlayerWith (OpponentN 2) attackingP2
+    attackPlayerWith (OpponentN 3) attackingP3
+
+    forCards (matchController (OpponentN 1) <> matchCanBlock) $ \blocker -> do
+      blockerColors <- view cardColors <$> requireCard blocker mempty
+
+      forM_ attackingP1 $
+        validate (matchAttribute flying `matchOr` matchProtectionAny blockerColors)
+
+    forCards (matchController (OpponentN 2) <> matchCanBlock) $ \blocker -> do
+      blockerColors <- view cardColors <$> requireCard blocker mempty
+
+      forM_ attackingP2 $
+        validate (matchAttribute flying `matchOr` matchProtectionAny blockerColors)
+
+    forCards (matchController (OpponentN 3) <> matchCanBlock) $ \blocker -> do
+      blockerColors <- view cardColors <$> requireCard blocker mempty
+
+      forM_ attackingP3 $
+        validate (matchAttribute flying `matchOr` matchProtectionAny blockerColors)
+
+    forM_ attackingP1 $ combatDamageTo (TargetPlayer $ OpponentN 1) []
+    forM_ attackingP2 $ combatDamageTo (TargetPlayer $ OpponentN 2) []
+    forM_ attackingP3 $ combatDamageTo (TargetPlayer $ OpponentN 3) []
+
+    trigger "Another combat phase" "Port Razer"
+    trigger "Treasures" "Malcolm, Keen-Eyed Navigator"
+
+    validateLife 0 (OpponentN 1)
+    validateLife 0 (OpponentN 2)
+    validateLife 0 (OpponentN 3)
+
 attach cn tn = do
   c <- requireCard cn $ matchInPlay
   

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -42,6 +42,7 @@ solution = do
       withZone Hand $ do
         withAttribute flying $ addCreature (2, 2) "Malcolm, Keen-Eyed Navigator"
         addInstant "Soul's Fire"
+        addInstant "Wrong Turn"
 
       withZone Command $ do
         withAttribute commander
@@ -147,8 +148,13 @@ solution = do
 
     validateLife 31 (OpponentN 3)
 
-    trigger "Another combat phase" "Port Razer" >> resolveTop
+    trigger "Another combat phase" "Port Razer"
+    trigger "Treasures" "Malcolm, Keen-Eyed Navigator"
 
+    resolveTop
+    withZone Play $ addArtifact "Treasure 1"
+
+    resolveTop
     forCards (matchInPlay <> matchController Active) $ \cn -> do
       loseAttribute attacking cn
       loseAttribute tapped cn
@@ -208,9 +214,38 @@ solution = do
     forM_ attackingP2 $ combatDamageTo (TargetPlayer $ OpponentN 2) []
     forM_ attackingP3 $ combatDamageTo (TargetPlayer $ OpponentN 3) []
 
+    trigger "Another combat phase" "Port Razer"
+    trigger "Treasures" "Malcolm, Keen-Eyed Navigator"
+
     validateLife 27 (OpponentN 1)
     validateLife 16 (OpponentN 2)
     validateLife 14 (OpponentN 3)
+
+  step "Resolve combat triggers" $ do
+    -- TODO: Automatically figure out how many there should be, or validate
+    resolve "Treasures"
+    withZone Play $ addArtifact "Treasure 2"
+    withZone Play $ addArtifact "Treasure 3"
+
+    tapForMana "U" "Treasure 1"
+    tapForMana "U" "Treasure 2"
+    tapForMana "U" "Treasure 3"
+
+    sacrifice "Treasure 1"
+    sacrifice "Treasure 2"
+    sacrifice "Treasure 3"
+
+    cast "2U" "Wrong Turn" >> resolveTop
+
+    addEffect (effectControl (OpponentN 1)) "Archon of Coronation"
+    gainAttribute summoned "Archon of Coronation"
+
+    resolve "Another combat phase"
+    forCards (matchInPlay <> matchController Active) $ \cn -> do
+      loseAttribute attacking cn
+      loseAttribute tapped cn
+
+    transitionToForced BeginCombat
 
 attach cn tn = do
   c <- requireCard cn $ matchInPlay

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -259,6 +259,8 @@ attach cn tn = do
 matchCanBlock =
   matchInPlay <> matchAttribute creature <> missingAttribute tapped
 
+-- TODO: This probably belongs in core, let's find some other uses first
+-- though.
 matchAttached :: EffectMonad CardMatcher
 matchAttached =
   matchAny matchName . mapMaybe extractCardTarget <$> viewSelf cardTargets
@@ -344,6 +346,8 @@ attackPlayerWith player cs = do
       (gainAttribute tapped)
     gainAttribute attacking cn
 
+-- TODO: This probably belongs in core, but let's find some other use cases for
+-- it first.
 check matcher cn =
   (requireCard cn matcher >> pure True) `catchError` const (pure False)
 

--- a/src/Solutions/CommanderLegends.hs
+++ b/src/Solutions/CommanderLegends.hs
@@ -1,5 +1,5 @@
 module Solutions.CommanderLegends where
-import Dovin.V3
+import Dovin.V4
 
 import Data.Maybe (mapMaybe)
 
@@ -292,7 +292,7 @@ attackPlayerTo opponent expectedLife attackers = do
 
       let name = "Angel " <> show n
 
-      withLocation Play
+      withZone Play
         $ withAttributes [token, tapped, attacking, flying]
         $ addCreature (4, 4) name
 
@@ -345,11 +345,6 @@ attackPlayerWith player cs = do
       -- Can't use 'tap' here because it checks summoning sickness.
       (gainAttribute tapped)
     gainAttribute attacking cn
-
--- TODO: This probably belongs in core, but let's find some other use cases for
--- it first.
-check matcher cn =
-  (requireCard cn matcher >> pure True) `catchError` const (pure False)
 
 angelCounter :: Control.Lens.Lens' Board Int
 angelCounter = counters . at "angels" . non 0

--- a/src/Solutions/Example.hs
+++ b/src/Solutions/Example.hs
@@ -7,12 +7,12 @@ solution = do
   step "Initial state" $ do
     as Opponent $ setLife 3
 
-    withLocation Hand $ addInstant "Plummet"
-    withLocation Play $ do
+    withZone Hand $ addInstant "Plummet"
+    withZone Play $ do
       addLands 2 "Forest"
 
     as Opponent $ do
-      withLocation Play $ do
+      withZone Play $ do
         withAttributes [flying, token] $ addCreature (4, 4) "Angel"
         withAttributes [flying]
           $ withEffect

--- a/src/Solutions/Example.hs
+++ b/src/Solutions/Example.hs
@@ -35,7 +35,8 @@ solution = do
 formatter :: Step -> Formatter
 formatter step = case view stepNumber step of
   1 -> manaFormatter
-    <> cardFormatter "opponent creatures" (matchLocation (Opponent, Play))
+    <> cardFormatter "opponent creatures"
+         (matchController Opponent <> matchZone Play)
   _ -> boardFormatter
 
 manaFormatter = attributeFormatter $ do

--- a/test/CastFromZone.hs
+++ b/test/CastFromZone.hs
@@ -1,0 +1,53 @@
+module CastFromZone where
+
+import TestPrelude.V4
+
+test_CastFromZone = testGroup "castFromZone"
+  [ prove "places card on top of stack, spending mana" $ do
+      withZone Graveyard $ addCreature (1, 1) "Zombie"
+      addMana "B"
+      castFromZone Graveyard "B" "Zombie"
+      validate (matchZone Stack) "Zombie"
+      validateBoardEquals (manaPoolFor Active) mempty
+
+  , refute
+      "requires mana be available"
+      "Mana pool () does not contain (B)" $ do
+        withZone Hand $ addCreature (1, 1) "Zombie"
+        castFromZone Hand "B" "Zombie"
+
+  , prove "can cast non-instant in second main" $ do
+      withZone Hand $ addSorcery "Lava Spike"
+      transitionTo SecondMain
+      castFromZone Hand "" "Lava Spike"
+
+  , refute
+      "requires main phase for non-instant"
+      "not in a main phase" $ do
+        withZone Hand $ addSorcery "Lava Spike"
+        transitionTo BeginCombat
+        castFromZone Hand "" "Lava Spike"
+
+  , refute
+      "requires stack to be empty for non-instant"
+      "stack is not empty" $ do
+        withZone Hand $ addInstant "Shock"
+        withZone Hand $ addSorcery "Lava Spike"
+
+        castFromZone Hand "" "Shock"
+        castFromZone Hand "" "Lava Spike"
+
+  , prove "increases storm count if instant" $ do
+      withZone Hand $ addInstant "Shock"
+      castFromZone Hand "" "Shock"
+      validateBoardEquals (counters . at "storm" . non 0) 1
+
+  , prove "increases storm count if sorcery" $ do
+      withZone Hand $ addSorcery "Lava Spike"
+      castFromZone Hand "" "Lava Spike"
+
+  , prove "does not increase storm count otherwise" $ do
+      withZone Hand $ addArtifact "Mox Amber"
+      castFromZone Hand "" "Mox Amber"
+      validateBoardEquals (counters . at "storm" . non 0) 0
+  ]

--- a/test/Damage.hs
+++ b/test/Damage.hs
@@ -158,3 +158,12 @@ test_CombatDamage = testGroup "combatDamage"
         attackWith ["Angel"]
         as Opponent $ combatDamage [] "Angel"
   ]
+
+test_CombatDamageTo = testGroup "combatDamageTo"
+  [ prove "damages opponent when no blockers" $ do
+      withLocation (Active, Play) $ addCreature (4, 4) "Angel"
+      attackWith ["Angel"]
+      combatDamageTo (TargetPlayer $ OpponentN 1) [] "Angel"
+      validateLife Opponent 0
+      validateLife (OpponentN 1) (-4)
+  ]

--- a/test/Fight.hs
+++ b/test/Fight.hs
@@ -2,6 +2,8 @@ module Fight where
 
 import TestPrelude
 
+import Debug.Trace
+
 test_Fight = testGroup "fight"
   [ prove "adds damage to both creatures" $ do
       withLocation (Active, Play) $ addCreature (2, 4) "Angel 1"
@@ -20,6 +22,10 @@ test_Fight = testGroup "fight"
       "in play" $ do
         withLocation (Active, Graveyard) $ addCreature (2, 4) "Angel 1"
         withLocation (Active, Play) $ addCreature (3, 4) "Angel 2"
+
+        c <- requireCard "Angel 1" matchInPlay
+
+        traceM (show $ view cardLocation c)
 
         fight "Angel 1" "Angel 2"
   , refute

--- a/test/Fight.hs
+++ b/test/Fight.hs
@@ -2,8 +2,6 @@ module Fight where
 
 import TestPrelude
 
-import Debug.Trace
-
 test_Fight = testGroup "fight"
   [ prove "adds damage to both creatures" $ do
       withLocation (Active, Play) $ addCreature (2, 4) "Angel 1"
@@ -22,10 +20,6 @@ test_Fight = testGroup "fight"
       "in play" $ do
         withLocation (Active, Graveyard) $ addCreature (2, 4) "Angel 1"
         withLocation (Active, Play) $ addCreature (3, 4) "Angel 2"
-
-        c <- requireCard "Angel 1" matchInPlay
-
-        traceM (show $ view cardLocation c)
 
         fight "Angel 1" "Angel 2"
   , refute

--- a/test/Flashback.hs
+++ b/test/Flashback.hs
@@ -14,7 +14,7 @@ test_Flashback = testGroup "flashback"
         validateBoardEquals (manaPoolFor Active) mempty
   , refute
       "requires card in graveyard"
-      "in location (Active,Graveyard)" $ do
+      "in zone Graveyard" $ do
         withLocation Hand $ addInstant "Shock"
         flashback "" "Shock"
   ]

--- a/test/Jumpstart.hs
+++ b/test/Jumpstart.hs
@@ -18,7 +18,7 @@ test_Cases = testGroup "jumpstart"
         validateBoardEquals (manaPoolFor Active) mempty
   , refute
       "requires card in graveyard"
-      "in location (Active,Graveyard)" $ do
+      "in zone Graveyard" $ do
         withLocation Hand $ addInstant "Shock"
         withLocation Hand $ addLand "Mountain"
         jumpstart "" "Mountain" "Shock"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -26,55 +26,6 @@ test_Test = testGroup "Actions"
           withLocation (Active, Play) $ addCreature (1, 1) "Zombie"
           cast "" "Zombie"
     ]
-  , testGroup "castFromLocation"
-    [ prove "places card on top of stack, spending mana" $ do
-        withLocation (Active, Graveyard) $ addCreature (1, 1) "Zombie"
-        addMana "B"
-        castFromLocation (Active, Graveyard) "B" "Zombie"
-        validate "Zombie" $ matchLocation (Active, Stack)
-        validateBoardEquals (manaPoolFor Active) mempty
-
-    , refute
-        "requires mana be available"
-        "Mana pool () does not contain (B)" $ do
-          withLocation (Active, Hand) $ addCreature (1, 1) "Zombie"
-          castFromLocation (Active, Hand) "B" "Zombie"
-
-    , prove "can cast non-instant in second main" $ do
-        withLocation (Active, Hand) $ addSorcery "Lava Spike"
-        transitionTo SecondMain
-        castFromLocation (Active, Hand) "" "Lava Spike"
-
-    , refute
-        "requires main phase for non-instant"
-        "not in a main phase" $ do
-          withLocation (Active, Hand) $ addSorcery "Lava Spike"
-          transitionTo BeginCombat
-          castFromLocation (Active, Hand) "" "Lava Spike"
-
-    , refute
-        "requires stack to be empty for non-instant"
-        "stack is not empty" $ do
-          withLocation (Active, Hand) $ addInstant "Shock"
-          withLocation (Active, Hand) $ addSorcery "Lava Spike"
-
-          castFromLocation (Active, Hand) "" "Shock"
-          castFromLocation (Active, Hand) "" "Lava Spike"
-
-    , prove "increases storm count if instant" $ do
-        withLocation (Active, Hand) $ addInstant "Shock"
-        castFromLocation (Active, Hand) "" "Shock"
-        validateBoardEquals (counters . at "storm" . non 0) 1
-
-    , prove "increases storm count if sorcery" $ do
-        withLocation (Active, Hand) $ addSorcery "Lava Spike"
-        castFromLocation (Active, Hand) "" "Lava Spike"
-
-    , prove "does not increase storm count otherwise" $ do
-        withLocation (Active, Hand) $ addArtifact "Mox Amber"
-        castFromLocation (Active, Hand) "" "Mox Amber"
-        validateBoardEquals (counters . at "storm" . non 0) 0
-    ]
   , testGroup "spendMana"
     [ prove "removes colored mana from pool" $ do
         addMana "BBRRRWW"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,7 +22,7 @@ test_Test = testGroup "Actions"
           validateBoardEquals (manaPoolFor Opponent) mempty
     , refute
         "requires card to be in hand"
-        "Zombie does not match requirements: in location (Active,Hand)" $ do
+        "Zombie does not match requirements: in zone Hand" $ do
           withLocation (Active, Play) $ addCreature (1, 1) "Zombie"
           cast "" "Zombie"
     ]

--- a/test/TestPrelude/V4.hs
+++ b/test/TestPrelude/V4.hs
@@ -1,0 +1,16 @@
+module TestPrelude.V4
+  ( module TestPrelude.V3
+  , module Dovin.V4
+  , module Control.Lens
+  ) where
+
+import Control.Lens
+
+import Dovin.V4
+import TestPrelude.V3
+  ( prove
+  , refute
+  , validateBoardEquals
+  , throwError
+  , testGroup
+  )


### PR DESCRIPTION
* Cards can target other cards, and use that information in effects. This allows for both equipment and auras to be implemented neatly.
* Added a control changing effect, to allow for auras like `Confiscate`.
* Deprecated card location, replaced with explicit zone and controller data fields.
* Added card colors.
* Added protection from effect (though note: no in-built matchers respect it yet, e.g. `target`)
* Support for multiple opponents through `OpponentN Int` constructor for `Player`, and `combatDamageTo` action to attack specific players.
* Not pulled into core yet, but a new action `check` for branching based on whether a card meets conditions.
* Fix that artifacts were being created as enchantments as well as artifacts.